### PR TITLE
[Common] InputValue XIcon Delete Rendering

### DIFF
--- a/shared/common/src/atoms/index.ts
+++ b/shared/common/src/atoms/index.ts
@@ -21,7 +21,7 @@ export const Page2Obj = atom({
   default: [
     { value: '', placeholder: '학교 이름 선택', type: 'text' },
     { value: '', placeholder: '동아리 이름 선택', type: 'text' },
-    { value: '', placeholder: '이름 입력', type: 'text', maxLength: 3 },
+    { value: '', placeholder: '이름 입력', type: 'text', maxLength: 4 },
   ],
 })
 

--- a/shared/common/src/atoms/index.ts
+++ b/shared/common/src/atoms/index.ts
@@ -21,7 +21,7 @@ export const Page2Obj = atom({
   default: [
     { value: '', placeholder: '학교 이름 선택', type: 'text' },
     { value: '', placeholder: '동아리 이름 선택', type: 'text' },
-    { value: '', placeholder: '이름 입력', type: 'text', maxLength: 4 },
+    { value: '', placeholder: '이름 입력', type: 'text', maxLength: 3 },
   ],
 })
 

--- a/shared/common/src/components/ValueInput/index.tsx
+++ b/shared/common/src/components/ValueInput/index.tsx
@@ -1,4 +1,9 @@
-import React, { useState, forwardRef, InputHTMLAttributes } from 'react'
+import React, {
+  useState,
+  forwardRef,
+  InputHTMLAttributes,
+  useEffect,
+} from 'react'
 import * as S from './style'
 import { XIcon } from '../../assets'
 
@@ -12,6 +17,12 @@ const ValueInput = (
   ref?: any
 ) => {
   const [focus, setFocus] = useState<boolean>(true)
+
+  useEffect(() => {
+    return () => {
+      setFocus(false)
+    }
+  }, [])
 
   return (
     <S.ValueWrapper


### PR DESCRIPTION
## 💡 개요
> 정보를 입력하고 이전으로 돌아가면 XIcon 남아있는 부문 수정하였습니다.

## 📃 작업내용
> 렌더링이 다시 될 경우 useEffect를 사용하여서 focus에 false값으로 설정하였습니다.

> + 이전으로 갔을 때 다시 렌더링 된 UI

![image](https://github.com/GSM-MSG/Bitgouel-Frontend/assets/106226701/7321b5ca-f2c9-4050-8102-9178b0a59548)

## 🎸 기타
