### PR TITLE
[Admin, Client, Common] 모든 API import 정리, 절대 경로 지정

### DIFF
--- a/shared/api/admin/admin/useDeleteUserReject.ts
+++ b/shared/api/admin/admin/useDeleteUserReject.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query'
-import { adminQueryKeys, adminUrl, del } from '../../common'
+import { adminQueryKeys, adminUrl, del } from '@bitgouel/api'
 
 export const useDeleteUserReject = (userIds: string[]) =>
   useMutation<void>(

--- a/shared/api/admin/admin/useDeleteUserReject.ts
+++ b/shared/api/admin/admin/useDeleteUserReject.ts
@@ -1,5 +1,5 @@
-import { useMutation } from '@tanstack/react-query'
 import { adminQueryKeys, adminUrl, del } from '@bitgouel/api'
+import { useMutation } from '@tanstack/react-query'
 
 export const useDeleteUserReject = (userIds: string[]) =>
   useMutation<void>(

--- a/shared/api/admin/admin/useDeleteUserWithdraw.ts
+++ b/shared/api/admin/admin/useDeleteUserWithdraw.ts
@@ -1,5 +1,5 @@
-import { useMutation } from '@tanstack/react-query'
 import { adminQueryKeys, adminUrl, del } from '@bitgouel/api'
+import { useMutation } from '@tanstack/react-query'
 
 export const useDeleteUserWithdraw = (userIds: string[]) =>
   useMutation<void>(

--- a/shared/api/admin/admin/useDeleteUserWithdraw.ts
+++ b/shared/api/admin/admin/useDeleteUserWithdraw.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query'
-import { adminQueryKeys, adminUrl, del } from '../../common'
+import { adminQueryKeys, adminUrl, del } from '@bitgouel/api'
 
 export const useDeleteUserWithdraw = (userIds: string[]) =>
   useMutation<void>(

--- a/shared/api/admin/admin/useGetDepartment.ts
+++ b/shared/api/admin/admin/useGetDepartment.ts
@@ -1,9 +1,12 @@
 import { ApiErrorTypes, DepartmentResponseTypes } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosError, AxiosResponse } from 'axios'
-import { get, lectureQueryKeys, lectureUrl } from '../../common'
+import { get, lectureQueryKeys, lectureUrl } from '@bitgouel/api'
 
-export const useGetDepartment = (keyword: string,options?: UseQueryOptions<AxiosResponse>) =>
+export const useGetDepartment = (
+  keyword: string,
+  options?: UseQueryOptions<AxiosResponse>
+) =>
   useQuery<AxiosResponse<DepartmentResponseTypes>, AxiosError<ApiErrorTypes>>(
     lectureQueryKeys.getDepartment(),
     () => get(lectureUrl.lectureDepartment(keyword)),

--- a/shared/api/admin/admin/useGetDepartment.ts
+++ b/shared/api/admin/admin/useGetDepartment.ts
@@ -1,7 +1,7 @@
+import { get, lectureQueryKeys, lectureUrl } from '@bitgouel/api'
 import { ApiErrorTypes, DepartmentResponseTypes } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosError, AxiosResponse } from 'axios'
-import { get, lectureQueryKeys, lectureUrl } from '@bitgouel/api'
 
 export const useGetDepartment = (
   keyword: string,

--- a/shared/api/admin/admin/useGetLine.ts
+++ b/shared/api/admin/admin/useGetLine.ts
@@ -1,7 +1,11 @@
-import { ApiErrorTypes, LinePayloadTypes, LineResponseTypes } from '@bitgouel/types'
+import {
+  ApiErrorTypes,
+  LinePayloadTypes,
+  LineResponseTypes,
+} from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosError, AxiosResponse } from 'axios'
-import { get, lectureQueryKeys, lectureUrl } from '../../common'
+import { get, lectureQueryKeys, lectureUrl } from '@bitgouel/api'
 
 export const useGetLine = (
   queryString: LinePayloadTypes,

--- a/shared/api/admin/admin/useGetLine.ts
+++ b/shared/api/admin/admin/useGetLine.ts
@@ -1,3 +1,4 @@
+import { get, lectureQueryKeys, lectureUrl } from '@bitgouel/api'
 import {
   ApiErrorTypes,
   LinePayloadTypes,
@@ -5,7 +6,6 @@ import {
 } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosError, AxiosResponse } from 'axios'
-import { get, lectureQueryKeys, lectureUrl } from '@bitgouel/api'
 
 export const useGetLine = (
   queryString: LinePayloadTypes,

--- a/shared/api/admin/admin/useGetProfessor.ts
+++ b/shared/api/admin/admin/useGetProfessor.ts
@@ -1,7 +1,7 @@
 import { AxiosError, AxiosResponse } from 'axios'
 import { ApiErrorTypes, ProfessorResponseTypes } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
-import { get, lectureQueryKeys, lectureUrl } from '../../common'
+import { get, lectureQueryKeys, lectureUrl } from '@bitgouel/api'
 
 export const useGetProfessor = (
   keyword: string,

--- a/shared/api/admin/admin/useGetProfessor.ts
+++ b/shared/api/admin/admin/useGetProfessor.ts
@@ -1,7 +1,7 @@
-import { AxiosError, AxiosResponse } from 'axios'
+import { get, lectureQueryKeys, lectureUrl } from '@bitgouel/api'
 import { ApiErrorTypes, ProfessorResponseTypes } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
-import { get, lectureQueryKeys, lectureUrl } from '@bitgouel/api'
+import { AxiosError, AxiosResponse } from 'axios'
 
 export const useGetProfessor = (
   keyword: string,

--- a/shared/api/admin/admin/useGetUserList.ts
+++ b/shared/api/admin/admin/useGetUserList.ts
@@ -1,5 +1,5 @@
 import { UserListOptionsTypes, UserListResponseTypes } from '@bitgouel/types'
-import { adminQueryKeys, adminUrl, get } from '../../common'
+import { adminQueryKeys, adminUrl, get } from '@bitgouel/api'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
 

--- a/shared/api/admin/admin/useGetUserList.ts
+++ b/shared/api/admin/admin/useGetUserList.ts
@@ -1,5 +1,5 @@
-import { UserListOptionsTypes, UserListResponseTypes } from '@bitgouel/types'
 import { adminQueryKeys, adminUrl, get } from '@bitgouel/api'
+import { UserListOptionsTypes, UserListResponseTypes } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
 

--- a/shared/api/admin/admin/useGetWithDrawUserList.ts
+++ b/shared/api/admin/admin/useGetWithDrawUserList.ts
@@ -1,7 +1,7 @@
 import { WithdrawListResponseTypes } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
-import { adminQueryKeys, adminUrl, get } from '../../common'
+import { adminQueryKeys, adminUrl, get } from '@bitgouel/api'
 
 export const useGetWithDrawUserList = (
   cohort: string,

--- a/shared/api/admin/admin/useGetWithDrawUserList.ts
+++ b/shared/api/admin/admin/useGetWithDrawUserList.ts
@@ -1,7 +1,7 @@
+import { adminQueryKeys, adminUrl, get } from '@bitgouel/api'
 import { WithdrawListResponseTypes } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
-import { adminQueryKeys, adminUrl, get } from '@bitgouel/api'
 
 export const useGetWithDrawUserList = (
   cohort: string,

--- a/shared/api/admin/admin/usePatchUserApprove.ts
+++ b/shared/api/admin/admin/usePatchUserApprove.ts
@@ -1,5 +1,5 @@
-import { useMutation } from '@tanstack/react-query'
 import { adminQueryKeys, adminUrl, patch } from '@bitgouel/api'
+import { useMutation } from '@tanstack/react-query'
 
 export const usePatchUserApprove = (userIds: string[]) =>
   useMutation<void>(

--- a/shared/api/admin/admin/usePatchUserApprove.ts
+++ b/shared/api/admin/admin/usePatchUserApprove.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query'
-import { adminQueryKeys, adminUrl, patch } from '../../common'
+import { adminQueryKeys, adminUrl, patch } from '@bitgouel/api'
 
 export const usePatchUserApprove = (userIds: string[]) =>
   useMutation<void>(

--- a/shared/api/admin/admin/usePostLecture.ts
+++ b/shared/api/admin/admin/usePostLecture.ts
@@ -2,7 +2,7 @@ import { LectureCreatePayloadTypes } from '@bitgouel/types'
 import { useMutation } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
 import { useRouter } from 'next/navigation'
-import { lectureUrl, lectureQueryKeys, post } from '../../common'
+import { lectureUrl, lectureQueryKeys, post } from '@bitgouel/api'
 import { toast } from 'react-toastify'
 import { useModal } from '@bitgouel/common/src/hooks'
 

--- a/shared/api/admin/admin/usePostLecture.ts
+++ b/shared/api/admin/admin/usePostLecture.ts
@@ -1,10 +1,10 @@
+import { lectureQueryKeys, lectureUrl, post } from '@bitgouel/api'
+import { useModal } from '@bitgouel/common/src/hooks'
 import { LectureCreatePayloadTypes } from '@bitgouel/types'
 import { useMutation } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
 import { useRouter } from 'next/navigation'
-import { lectureUrl, lectureQueryKeys, post } from '@bitgouel/api'
 import { toast } from 'react-toastify'
-import { useModal } from '@bitgouel/common/src/hooks'
 
 export const usePostLecture = () => {
   const { push } = useRouter()

--- a/shared/api/admin/admin/usePostLecture.ts
+++ b/shared/api/admin/admin/usePostLecture.ts
@@ -1,5 +1,5 @@
 import { lectureQueryKeys, lectureUrl, post } from '@bitgouel/api'
-import { useModal } from '@bitgouel/common/src/hooks'
+import { useModal } from '@bitgouel/common'
 import { LectureCreatePayloadTypes } from '@bitgouel/types'
 import { useMutation } from '@tanstack/react-query'
 import { AxiosError } from 'axios'

--- a/shared/api/admin/club/useGetClubList.ts
+++ b/shared/api/admin/club/useGetClubList.ts
@@ -2,14 +2,13 @@ import { ClubListResponseTypes } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosError, AxiosResponse } from 'axios'
 import { ApiError } from 'next/dist/server/api-utils'
-import { clubQueryKeys, clubUrl, get } from '../../common'
+import { clubQueryKeys, clubUrl, get } from '@bitgouel/api'
 
 export const useGetClubList = (
   queryString: string,
   options?: UseQueryOptions<AxiosResponse>
-) => 
-
-useQuery<AxiosResponse<ClubListResponseTypes>, AxiosError<ApiError>>(
+) =>
+  useQuery<AxiosResponse<ClubListResponseTypes>, AxiosError<ApiError>>(
     clubQueryKeys.getClub(),
     () => get(clubUrl.club(queryString)),
     options

--- a/shared/api/admin/club/useGetClubList.ts
+++ b/shared/api/admin/club/useGetClubList.ts
@@ -1,8 +1,8 @@
+import { clubQueryKeys, clubUrl, get } from '@bitgouel/api'
 import { ClubListResponseTypes } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosError, AxiosResponse } from 'axios'
 import { ApiError } from 'next/dist/server/api-utils'
-import { clubQueryKeys, clubUrl, get } from '@bitgouel/api'
 
 export const useGetClubList = (
   queryString: string,

--- a/shared/api/admin/club/useGetSchoolClubList.ts
+++ b/shared/api/admin/club/useGetSchoolClubList.ts
@@ -1,8 +1,8 @@
+import { clubQueryKeys, clubUrl, get } from '@bitgouel/api'
 import { SchoolClubListResponseTypes } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosError, AxiosResponse } from 'axios'
 import { ApiError } from 'next/dist/server/api-utils'
-import { clubQueryKeys, clubUrl, get } from '@bitgouel/api'
 
 export const useGetSchoolClubList = (
   options?: UseQueryOptions<AxiosResponse>

--- a/shared/api/admin/club/useGetSchoolClubList.ts
+++ b/shared/api/admin/club/useGetSchoolClubList.ts
@@ -2,7 +2,7 @@ import { SchoolClubListResponseTypes } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosError, AxiosResponse } from 'axios'
 import { ApiError } from 'next/dist/server/api-utils'
-import { clubQueryKeys, clubUrl, get } from '../../common'
+import { clubQueryKeys, clubUrl, get } from '@bitgouel/api'
 
 export const useGetSchoolClubList = (
   options?: UseQueryOptions<AxiosResponse>

--- a/shared/api/admin/inquiry/useDeleteInquiryReject.ts
+++ b/shared/api/admin/inquiry/useDeleteInquiryReject.ts
@@ -1,10 +1,10 @@
+import { del, inquiryQueryKeys, inquiryUrl } from '@bitgouel/api'
 import { useModal } from '@bitgouel/common'
 import { ApiErrorTypes } from '@bitgouel/types'
 import { useMutation } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
 import { useRouter } from 'next/navigation'
 import { toast } from 'react-toastify'
-import { del, inquiryQueryKeys, inquiryUrl } from '@bitgouel/api'
 
 export const useDeleteInquiryReject = (id: string) => {
   const { push } = useRouter()

--- a/shared/api/admin/inquiry/useDeleteInquiryReject.ts
+++ b/shared/api/admin/inquiry/useDeleteInquiryReject.ts
@@ -4,7 +4,7 @@ import { useMutation } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
 import { useRouter } from 'next/navigation'
 import { toast } from 'react-toastify'
-import { del, inquiryQueryKeys, inquiryUrl } from '../../common'
+import { del, inquiryQueryKeys, inquiryUrl } from '@bitgouel/api'
 
 export const useDeleteInquiryReject = (id: string) => {
   const { push } = useRouter()

--- a/shared/api/admin/inquiry/useGetInquiryList.ts
+++ b/shared/api/admin/inquiry/useGetInquiryList.ts
@@ -1,10 +1,13 @@
-import { AnswerStatus, InquiryListQueryStringTypes } from '@bitgouel/types';
+import { AnswerStatus, InquiryListQueryStringTypes } from '@bitgouel/types'
 import { ApiErrorTypes, InquiryListResponseTypes } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosError, AxiosResponse } from 'axios'
-import { get, inquiryQueryKeys, inquiryUrl } from '../../common'
+import { get, inquiryQueryKeys, inquiryUrl } from '@bitgouel/api'
 
-export const useGetInquiryList = (queryString: InquiryListQueryStringTypes, options?: UseQueryOptions<AxiosResponse>) =>
+export const useGetInquiryList = (
+  queryString: InquiryListQueryStringTypes,
+  options?: UseQueryOptions<AxiosResponse>
+) =>
   useQuery<AxiosResponse<InquiryListResponseTypes>, AxiosError<ApiErrorTypes>>(
     inquiryQueryKeys.getInquiry(),
     () => get(inquiryUrl.inquiryList(queryString)),

--- a/shared/api/admin/inquiry/useGetInquiryList.ts
+++ b/shared/api/admin/inquiry/useGetInquiryList.ts
@@ -1,8 +1,7 @@
-import { AnswerStatus, InquiryListQueryStringTypes } from '@bitgouel/types'
-import { ApiErrorTypes, InquiryListResponseTypes } from '@bitgouel/types'
+import { get, inquiryQueryKeys, inquiryUrl } from '@bitgouel/api'
+import { ApiErrorTypes, InquiryListQueryStringTypes, InquiryListResponseTypes } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosError, AxiosResponse } from 'axios'
-import { get, inquiryQueryKeys, inquiryUrl } from '@bitgouel/api'
 
 export const useGetInquiryList = (
   queryString: InquiryListQueryStringTypes,

--- a/shared/api/admin/inquiry/usePostAnswer.ts
+++ b/shared/api/admin/inquiry/usePostAnswer.ts
@@ -3,7 +3,7 @@ import { ApiErrorTypes } from '@bitgouel/types'
 import { useMutation } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
 import { useRouter } from 'next/navigation'
-import { inquiryQueryKeys, inquiryUrl, post } from '../../common'
+import { inquiryQueryKeys, inquiryUrl, post } from '@bitgouel/api'
 import { toast } from 'react-toastify'
 
 export const usePostAnswer = (id: string) => {

--- a/shared/api/admin/inquiry/usePostAnswer.ts
+++ b/shared/api/admin/inquiry/usePostAnswer.ts
@@ -1,9 +1,9 @@
+import { inquiryQueryKeys, inquiryUrl, post } from '@bitgouel/api'
 import { useModal } from '@bitgouel/common'
 import { ApiErrorTypes } from '@bitgouel/types'
 import { useMutation } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
 import { useRouter } from 'next/navigation'
-import { inquiryQueryKeys, inquiryUrl, post } from '@bitgouel/api'
 import { toast } from 'react-toastify'
 
 export const usePostAnswer = (id: string) => {

--- a/shared/api/client/src/hooks/activity/useDeleteActivityInformationRemove.ts
+++ b/shared/api/client/src/hooks/activity/useDeleteActivityInformationRemove.ts
@@ -1,5 +1,5 @@
+import { activityQueryKeys, activityUrl, del } from '@bitgouel/api'
 import { useMutation } from '@tanstack/react-query'
-import { activityQueryKeys, del, activityUrl } from '@bitgouel/api'
 import { AxiosResponse } from 'axios'
 
 export const useDeleteInformationRemove = (activity_id: string) =>

--- a/shared/api/client/src/hooks/activity/useDeleteActivityInformationRemove.ts
+++ b/shared/api/client/src/hooks/activity/useDeleteActivityInformationRemove.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query'
-import { activityQueryKeys, del, activityUrl } from '../../../../common'
+import { activityQueryKeys, del, activityUrl } from '@bitgouel/api'
 import { AxiosResponse } from 'axios'
 
 export const useDeleteInformationRemove = (activity_id: string) =>

--- a/shared/api/client/src/hooks/activity/useGetActivityMyselfList.ts
+++ b/shared/api/client/src/hooks/activity/useGetActivityMyselfList.ts
@@ -1,7 +1,7 @@
-import { ActivityInformationTypes, ActivityOptionsTypes } from '@bitgouel/types'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
-import { AxiosResponse } from 'axios'
 import { activityQueryKeys, activityUrl, get } from '@bitgouel/api'
+import { ActivityInformationTypes, ActivityOptionsTypes } from '@bitgouel/types'
+import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { AxiosResponse } from 'axios'
 
 export const useGetActivityMyselfList = (
   queryString: ActivityOptionsTypes,

--- a/shared/api/client/src/hooks/activity/useGetActivityMyselfList.ts
+++ b/shared/api/client/src/hooks/activity/useGetActivityMyselfList.ts
@@ -1,7 +1,7 @@
 import { ActivityInformationTypes, ActivityOptionsTypes } from '@bitgouel/types'
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
-import { activityQueryKeys, activityUrl, get } from '../../../../common'
+import { activityQueryKeys, activityUrl, get } from '@bitgouel/api'
 
 export const useGetActivityMyselfList = (
   queryString: ActivityOptionsTypes,

--- a/shared/api/client/src/hooks/activity/usePatchActivityModifyInformation.ts
+++ b/shared/api/client/src/hooks/activity/usePatchActivityModifyInformation.ts
@@ -1,6 +1,6 @@
 import { ActivityPayloadTypes } from '@bitgouel/types'
 import { UseMutationOptions, useMutation } from '@tanstack/react-query'
-import { activityQueryKeys, activityUrl, patch } from '../../../../common'
+import { activityQueryKeys, activityUrl, patch } from '@bitgouel/api'
 
 export const usePatchActivityModifyInformation = (
   activityId: string,

--- a/shared/api/client/src/hooks/activity/usePatchActivityModifyInformation.ts
+++ b/shared/api/client/src/hooks/activity/usePatchActivityModifyInformation.ts
@@ -1,6 +1,6 @@
+import { activityQueryKeys, activityUrl, patch } from '@bitgouel/api'
 import { ActivityPayloadTypes } from '@bitgouel/types'
 import { UseMutationOptions, useMutation } from '@tanstack/react-query'
-import { activityQueryKeys, activityUrl, patch } from '@bitgouel/api'
 
 export const usePatchActivityModifyInformation = (
   activityId: string,

--- a/shared/api/client/src/hooks/activity/usePostActivityInformation.ts
+++ b/shared/api/client/src/hooks/activity/usePostActivityInformation.ts
@@ -1,7 +1,7 @@
 import { ActivityPayloadTypes } from '@bitgouel/types'
 import { UseMutationOptions, useMutation } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
-import { activityQueryKeys, activityUrl, post } from '../../../../common'
+import { activityQueryKeys, activityUrl, post } from '@bitgouel/api'
 
 export const usePostActivityInformation = (
   options: UseMutationOptions<void, Error, ActivityPayloadTypes>

--- a/shared/api/client/src/hooks/activity/usePostActivityInformation.ts
+++ b/shared/api/client/src/hooks/activity/usePostActivityInformation.ts
@@ -1,7 +1,6 @@
+import { activityQueryKeys, activityUrl, post } from '@bitgouel/api'
 import { ActivityPayloadTypes } from '@bitgouel/types'
 import { UseMutationOptions, useMutation } from '@tanstack/react-query'
-import { AxiosResponse } from 'axios'
-import { activityQueryKeys, activityUrl, post } from '@bitgouel/api'
 
 export const usePostActivityInformation = (
   options: UseMutationOptions<void, Error, ActivityPayloadTypes>

--- a/shared/api/client/src/hooks/certificate/useGetCertificateList.ts
+++ b/shared/api/client/src/hooks/certificate/useGetCertificateList.ts
@@ -1,7 +1,7 @@
+import { certificateQueryKeys, certificateUrl, get } from '@bitgouel/api'
 import { CertificateResponseTypes } from '@bitgouel/types'
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
-import { certificateQueryKeys, certificateUrl, get } from '@bitgouel/api'
 
 export const useGetCertificateList = (
   options?: UseQueryOptions<AxiosResponse>

--- a/shared/api/client/src/hooks/certificate/useGetCertificateList.ts
+++ b/shared/api/client/src/hooks/certificate/useGetCertificateList.ts
@@ -1,7 +1,7 @@
 import { CertificateResponseTypes } from '@bitgouel/types'
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
-import { certificateQueryKeys, certificateUrl, get } from '../../../../common'
+import { certificateQueryKeys, certificateUrl, get } from '@bitgouel/api'
 
 export const useGetCertificateList = (
   options?: UseQueryOptions<AxiosResponse>

--- a/shared/api/client/src/hooks/certificate/useGetCertificateListTeacher.ts
+++ b/shared/api/client/src/hooks/certificate/useGetCertificateListTeacher.ts
@@ -1,7 +1,7 @@
 import { CertificateResponseTypes } from '@bitgouel/types'
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
-import { certificateQueryKeys, certificateUrl, get } from '../../../../common'
+import { certificateQueryKeys, certificateUrl, get } from '@bitgouel/api'
 
 export const useGetCertificateListTeacher = (
   student_id: string,

--- a/shared/api/client/src/hooks/certificate/useGetCertificateListTeacher.ts
+++ b/shared/api/client/src/hooks/certificate/useGetCertificateListTeacher.ts
@@ -1,7 +1,7 @@
+import { certificateQueryKeys, certificateUrl, get } from '@bitgouel/api'
 import { CertificateResponseTypes } from '@bitgouel/types'
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
-import { certificateQueryKeys, certificateUrl, get } from '@bitgouel/api'
 
 export const useGetCertificateListTeacher = (
   student_id: string,

--- a/shared/api/client/src/hooks/certificate/usePatchModifyCertificate.ts
+++ b/shared/api/client/src/hooks/certificate/usePatchModifyCertificate.ts
@@ -1,7 +1,7 @@
 import { Certificate } from '@bitgouel/types'
 import { useMutation } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
-import { certificateQueryKeys, certificateUrl, patch } from '../../../../common'
+import { certificateQueryKeys, certificateUrl, patch } from '@bitgouel/api'
 
 export const usePatchModifyCertificate = (id: string | undefined) => {
   return useMutation<void, AxiosError, Certificate>(

--- a/shared/api/client/src/hooks/certificate/usePatchModifyCertificate.ts
+++ b/shared/api/client/src/hooks/certificate/usePatchModifyCertificate.ts
@@ -1,7 +1,7 @@
+import { certificateQueryKeys, certificateUrl, patch } from '@bitgouel/api'
 import { Certificate } from '@bitgouel/types'
 import { useMutation } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
-import { certificateQueryKeys, certificateUrl, patch } from '@bitgouel/api'
 
 export const usePatchModifyCertificate = (id: string | undefined) => {
   return useMutation<void, AxiosError, Certificate>(

--- a/shared/api/client/src/hooks/certificate/usePostCertificate.ts
+++ b/shared/api/client/src/hooks/certificate/usePostCertificate.ts
@@ -1,7 +1,7 @@
+import { certificateQueryKeys, certificateUrl, post } from '@bitgouel/api'
 import { CertificateRequest } from '@bitgouel/types'
 import { UseMutationOptions, useMutation } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
-import { certificateQueryKeys, certificateUrl, post } from '@bitgouel/api'
 
 export const usePostCertificate = (
   options: UseMutationOptions<void, Error, CertificateRequest>

--- a/shared/api/client/src/hooks/club/useGetClubDetail.ts
+++ b/shared/api/client/src/hooks/club/useGetClubDetail.ts
@@ -1,10 +1,13 @@
-import { clubQueryKeys, clubUrl, get } from '../../../../common'
+import { clubQueryKeys, clubUrl, get } from '@bitgouel/api'
 import { ClubDetailResponseTypes } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosError, AxiosResponse } from 'axios'
 import { ApiError } from 'next/dist/server/api-utils'
 
-export const useGetClubDetail = (club_id: string, options?: UseQueryOptions<AxiosResponse>) =>
+export const useGetClubDetail = (
+  club_id: string,
+  options?: UseQueryOptions<AxiosResponse>
+) =>
   useQuery<AxiosResponse<ClubDetailResponseTypes>, AxiosError<ApiError>>(
     clubQueryKeys.getClubDetail(),
     () => get(clubUrl.clubDetail(club_id)),

--- a/shared/api/client/src/hooks/club/useGetMyClub.ts
+++ b/shared/api/client/src/hooks/club/useGetMyClub.ts
@@ -1,8 +1,8 @@
+import { clubQueryKeys, clubUrl, get } from '@bitgouel/api'
 import { ClubDetailResponseTypes } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosError, AxiosResponse } from 'axios'
 import { ApiError } from 'next/dist/server/api-utils'
-import { clubQueryKeys, clubUrl, get } from '@bitgouel/api'
 
 export const useGetMyClub = (options?: UseQueryOptions<AxiosResponse>) =>
   useQuery<AxiosResponse<ClubDetailResponseTypes>, AxiosError<ApiError>>(

--- a/shared/api/client/src/hooks/club/useGetMyClub.ts
+++ b/shared/api/client/src/hooks/club/useGetMyClub.ts
@@ -2,7 +2,7 @@ import { ClubDetailResponseTypes } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosError, AxiosResponse } from 'axios'
 import { ApiError } from 'next/dist/server/api-utils'
-import { clubQueryKeys, clubUrl, get } from '../../../../common'
+import { clubQueryKeys, clubUrl, get } from '@bitgouel/api'
 
 export const useGetMyClub = (options?: UseQueryOptions<AxiosResponse>) =>
   useQuery<AxiosResponse<ClubDetailResponseTypes>, AxiosError<ApiError>>(

--- a/shared/api/client/src/hooks/club/useGetStudentDetail.ts
+++ b/shared/api/client/src/hooks/club/useGetStudentDetail.ts
@@ -1,5 +1,5 @@
-import { ClubStudentResponseTypes } from '@bitgouel/types'
 import { clubQueryKeys, clubUrl, get } from '@bitgouel/api'
+import { ClubStudentResponseTypes } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosError, AxiosResponse } from 'axios'
 import { ApiError } from 'next/dist/server/api-utils'

--- a/shared/api/client/src/hooks/club/useGetStudentDetail.ts
+++ b/shared/api/client/src/hooks/club/useGetStudentDetail.ts
@@ -1,5 +1,5 @@
 import { ClubStudentResponseTypes } from '@bitgouel/types'
-import { clubQueryKeys, clubUrl, get } from '../../../../common'
+import { clubQueryKeys, clubUrl, get } from '@bitgouel/api'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosError, AxiosResponse } from 'axios'
 import { ApiError } from 'next/dist/server/api-utils'

--- a/shared/api/client/src/hooks/lecture/usePostEnrollment.ts
+++ b/shared/api/client/src/hooks/lecture/usePostEnrollment.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query'
-import { lectureQueryKeys, lectureUrl, post } from '../../../../common'
+import { lectureQueryKeys, lectureUrl, post } from '@bitgouel/api'
 import { AxiosError } from 'axios'
 import { useRouter } from 'next/navigation'
 import { useModal } from '@bitgouel/common/src/hooks'
@@ -19,10 +19,9 @@ export const usePostEnrollment = (id: string) => {
         push('/main/lecture')
         toast.success('수강신청을 완료하였습니다')
       },
-      onError: ({response}) => {
-        toast.error(response?.data.message.split(".")[0])
+      onError: ({ response }) => {
+        toast.error(response?.data.message.split('.')[0])
       },
     }
   )
 }
-

--- a/shared/api/client/src/hooks/lecture/usePostEnrollment.ts
+++ b/shared/api/client/src/hooks/lecture/usePostEnrollment.ts
@@ -1,10 +1,10 @@
-import { useMutation } from '@tanstack/react-query'
 import { lectureQueryKeys, lectureUrl, post } from '@bitgouel/api'
+import { useModal } from '@bitgouel/common/src/hooks'
+import { ApiErrorTypes } from '@bitgouel/types'
+import { useMutation } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
 import { useRouter } from 'next/navigation'
-import { useModal } from '@bitgouel/common/src/hooks'
 import { toast } from 'react-toastify'
-import { ApiErrorTypes } from '@bitgouel/types'
 
 export const usePostEnrollment = (id: string) => {
   const { push } = useRouter()

--- a/shared/api/client/src/hooks/lecture/usePostEnrollment.ts
+++ b/shared/api/client/src/hooks/lecture/usePostEnrollment.ts
@@ -1,5 +1,5 @@
 import { lectureQueryKeys, lectureUrl, post } from '@bitgouel/api'
-import { useModal } from '@bitgouel/common/src/hooks'
+import { useModal } from '@bitgouel/common'
 import { ApiErrorTypes } from '@bitgouel/types'
 import { useMutation } from '@tanstack/react-query'
 import { AxiosError } from 'axios'

--- a/shared/api/common/src/hooks/auth/useDeleteWithDraw.ts
+++ b/shared/api/common/src/hooks/auth/useDeleteWithDraw.ts
@@ -1,7 +1,7 @@
+import { TokenManager, authQueryKeys, authUrl, del } from '@bitgouel/api'
 import { useMutation } from '@tanstack/react-query'
 import { useRouter } from 'next/navigation'
 import { toast } from 'react-toastify'
-import { authUrl, del, authQueryKeys, TokenManager } from '@bitgouel/api'
 
 export const useDeleteWithDraw = () => {
   const tokenManager = new TokenManager()

--- a/shared/api/common/src/hooks/auth/usePostStudentSignUp.ts
+++ b/shared/api/common/src/hooks/auth/usePostStudentSignUp.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { authQueryKeys, authUrl, post } from '@bitgouel/api'
 import { ApiErrorTypes, StudentPayloadTypes } from '@bitgouel/types'
 import { UseMutationOptions, useMutation } from '@tanstack/react-query'

--- a/shared/api/common/src/hooks/auth/usePostTeacherSignUp.ts
+++ b/shared/api/common/src/hooks/auth/usePostTeacherSignUp.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { authQueryKeys, authUrl, post } from '@bitgouel/api'
 import { ApiErrorTypes, TeacherPayloadTypes } from '@bitgouel/types'
 import { UseMutationOptions, useMutation } from '@tanstack/react-query'

--- a/shared/api/common/src/hooks/inquiry/useGetInquiryDetail.ts
+++ b/shared/api/common/src/hooks/inquiry/useGetInquiryDetail.ts
@@ -1,7 +1,7 @@
-import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { get, inquiryQueryKeys, inquiryUrl } from '@bitgouel/api'
-import { AxiosError, AxiosResponse } from 'axios'
 import { ApiErrorTypes, InquiryDetailResponseTypes } from '@bitgouel/types'
+import { UseQueryOptions, useQuery } from '@tanstack/react-query'
+import { AxiosError, AxiosResponse } from 'axios'
 
 export const useGetInquiryDetail = (
   id: string,

--- a/shared/api/common/src/hooks/lecture/useGetDetailLecture.ts
+++ b/shared/api/common/src/hooks/lecture/useGetDetailLecture.ts
@@ -1,6 +1,6 @@
 import { get, lectureQueryKeys, lectureUrl } from '@bitgouel/api'
 import { LectureDetailResponseTypes } from '@bitgouel/types'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
 
 export const useGetDetailLecture = (

--- a/shared/api/common/src/hooks/my/useGetMy.ts
+++ b/shared/api/common/src/hooks/my/useGetMy.ts
@@ -1,6 +1,6 @@
 import { get, myQueryKeys, userUrl } from '@bitgouel/api'
 import { MyPageResponseTypes } from '@bitgouel/types'
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
 
 export const useGetMy = (options?: UseQueryOptions<AxiosResponse>) =>


### PR DESCRIPTION
## 💡 개요
> 모든 API의 import 정리, 절대 경로 지정
## 📃 작업내용
> common에서 사용되는 urls, querykey, method `@bitgouel/api`로 통일하였습니다.
## 🎸 기타
