### PR TITLE
[Inside, Common] 남아있는 상대 경로 수정 및 학생활동 글자 수정

### DIFF
--- a/packages/inside/src/PageContainer/Club/ActivityWritePage/index.tsx
+++ b/packages/inside/src/PageContainer/Club/ActivityWritePage/index.tsx
@@ -82,7 +82,7 @@ const ActivityWritePage = ({
       openModal(
         <AppropriationModal
           isApprove={true}
-          question='게시글을 수정하시겠습니까?'
+          question='활동을 수정하시겠습니까?'
           title={activityTitle || ''}
           purpose='수정하기'
           onAppropriation={() =>
@@ -106,7 +106,7 @@ const ActivityWritePage = ({
       openModal(
         <AppropriationModal
           isApprove={true}
-          question='게시글을 추가하시겠습니까?'
+          question='활동을 추가하시겠습니까?'
           title={activityTitle || ''}
           purpose='추가하기'
           onAppropriation={() =>

--- a/shared/api/common/src/hooks/activity/useGetActivityList.ts
+++ b/shared/api/common/src/hooks/activity/useGetActivityList.ts
@@ -1,7 +1,7 @@
+import { activityQueryKeys, activityUrl, get } from '@bitgouel/api'
 import { ActivityInformationTypes, ActivityOptionsTypes } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
-import { activityQueryKeys, activityUrl, get } from '../../../../common'
 
 export const useGetActivityList = (
   studentId: string,

--- a/shared/api/common/src/hooks/activity/useGetActivityList.ts
+++ b/shared/api/common/src/hooks/activity/useGetActivityList.ts
@@ -1,7 +1,7 @@
-import { activityQueryKeys, activityUrl, get } from '@bitgouel/api'
 import { ActivityInformationTypes, ActivityOptionsTypes } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosResponse } from 'axios'
+import { activityQueryKeys, activityUrl, get } from '../../../../common'
 
 export const useGetActivityList = (
   studentId: string,

--- a/shared/api/tsconfig.json
+++ b/shared/api/tsconfig.json
@@ -1,11 +1,5 @@
 {
   "extends": "@bitgouel/tsconfig/base.json",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["./*"]
-    }
-  },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }

--- a/shared/api/tsconfig.json
+++ b/shared/api/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "extends": "@bitgouel/tsconfig/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }

--- a/shared/common/src/components/Header/index.tsx
+++ b/shared/common/src/components/Header/index.tsx
@@ -1,24 +1,18 @@
 'use client'
 
-import { TokenManager, useDeleteLogout, useGetLectureList } from '@bitgouel/api'
-import { usePathname, useRouter } from 'next/navigation'
-import { ChangeEvent, useEffect, useState } from 'react'
-import { toast } from 'react-toastify'
-import { useRecoilState } from 'recoil'
-import { match } from 'ts-pattern'
+import { TokenManager, useDeleteLogout } from '@bitgouel/api'
 import {
-  Filter,
-  FilterComponent,
-  LectureFilterType,
   Message,
-  Plus,
   Question,
   Symbol1,
   Symbol2,
-  theme,
+  theme
 } from '@bitgouel/common'
+import { usePathname, useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import { toast } from 'react-toastify'
+import { match } from 'ts-pattern'
 import * as S from './style'
-import { LectureTypeEnum, LectureTypesFilterListTypes } from '@bitgouel/types'
 
 const menuList = [
   { kor: '사업소개', link: '/' },
@@ -38,39 +32,8 @@ const Header = ({ is_admin }: { is_admin: boolean }) => {
   const [borderColor, setBorderColor] = useState<string>('')
   const [spanColor, setSpanColor] = useState<string>(`${theme.color.white}`)
   const [svgView, setSvgView] = useState<string>('none')
-  const [isLectureType, setIsLectureType] = useState<boolean>(false)
-  const [lectureTypes, setLectureTypes] = useState<
-    LectureTypesFilterListTypes[]
-  >([
-    { text: '전체', item: 'all', checked: true },
-    {
-      text: '상호학점인정교육과정',
-      item: 'MUTUAL_CREDIT_RECOGNITION_PROGRAM',
-      checked: false,
-    },
-    {
-      text: '대학탐방프로그램',
-      item: 'UNIVERSITY_EXPLORATION_PROGRAM',
-      checked: false,
-    },
-  ])
-  const [lectureType, setLectureType] = useRecoilState<LectureTypeEnum | ''>(
-    LectureFilterType
-  )
   const [text, setText] = useState<string>('로그인')
   const { mutate } = useDeleteLogout()
-
-  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setLectureTypes((prev) =>
-      prev.map((type) =>
-        type.item === e.target.id
-          ? { ...type, checked: true }
-          : { ...type, checked: false }
-      )
-    )
-    if (e.target.checked && e.target.id === 'all') setLectureType('')
-    else if (e.target.checked) setLectureType(e.target.id as LectureTypeEnum)
-  }
 
   useEffect(() => {
     const onScroll = () => {

--- a/shared/common/src/components/Header/index.tsx
+++ b/shared/common/src/components/Header/index.tsx
@@ -1,18 +1,24 @@
 'use client'
 
-import { TokenManager, useDeleteLogout } from '@bitgouel/api'
+import { TokenManager, useDeleteLogout, useGetLectureList } from '@bitgouel/api'
+import { usePathname, useRouter } from 'next/navigation'
+import { ChangeEvent, useEffect, useState } from 'react'
+import { toast } from 'react-toastify'
+import { useRecoilState } from 'recoil'
+import { match } from 'ts-pattern'
 import {
+  Filter,
+  FilterComponent,
+  LectureFilterType,
   Message,
+  Plus,
   Question,
   Symbol1,
   Symbol2,
-  theme
+  theme,
 } from '@bitgouel/common'
-import { usePathname, useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
-import { toast } from 'react-toastify'
-import { match } from 'ts-pattern'
 import * as S from './style'
+import { LectureTypeEnum, LectureTypesFilterListTypes } from '@bitgouel/types'
 
 const menuList = [
   { kor: '사업소개', link: '/' },
@@ -32,8 +38,39 @@ const Header = ({ is_admin }: { is_admin: boolean }) => {
   const [borderColor, setBorderColor] = useState<string>('')
   const [spanColor, setSpanColor] = useState<string>(`${theme.color.white}`)
   const [svgView, setSvgView] = useState<string>('none')
+  const [isLectureType, setIsLectureType] = useState<boolean>(false)
+  const [lectureTypes, setLectureTypes] = useState<
+    LectureTypesFilterListTypes[]
+  >([
+    { text: '전체', item: 'all', checked: true },
+    {
+      text: '상호학점인정교육과정',
+      item: 'MUTUAL_CREDIT_RECOGNITION_PROGRAM',
+      checked: false,
+    },
+    {
+      text: '대학탐방프로그램',
+      item: 'UNIVERSITY_EXPLORATION_PROGRAM',
+      checked: false,
+    },
+  ])
+  const [lectureType, setLectureType] = useRecoilState<LectureTypeEnum | ''>(
+    LectureFilterType
+  )
   const [text, setText] = useState<string>('로그인')
   const { mutate } = useDeleteLogout()
+
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setLectureTypes((prev) =>
+      prev.map((type) =>
+        type.item === e.target.id
+          ? { ...type, checked: true }
+          : { ...type, checked: false }
+      )
+    )
+    if (e.target.checked && e.target.id === 'all') setLectureType('')
+    else if (e.target.checked) setLectureType(e.target.id as LectureTypeEnum)
+  }
 
   useEffect(() => {
     const onScroll = () => {

--- a/shared/common/src/components/Sequence/index.tsx
+++ b/shared/common/src/components/Sequence/index.tsx
@@ -1,6 +1,7 @@
 'use client'
+
+import { Circle } from '@bitgouel/common'
 import * as S from './style'
-import { Circle } from '../../assets/index'
 
 const sequenceList = [
   { name: '사업소개', scroll: 722 },

--- a/shared/common/src/components/Sequence/index.tsx
+++ b/shared/common/src/components/Sequence/index.tsx
@@ -1,7 +1,6 @@
 'use client'
-
-import { Circle } from '@bitgouel/common'
 import * as S from './style'
+import { Circle } from '../../assets/index'
 
 const sequenceList = [
   { name: '사업소개', scroll: 722 },

--- a/shared/common/src/components/ValueInput/index.tsx
+++ b/shared/common/src/components/ValueInput/index.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { XIcon } from '@bitgouel/common'
-import { ValueInputProps } from '@bitgouel/types'
-import { Ref, forwardRef, useEffect, useState } from 'react'
+import { useState, forwardRef, useEffect, Ref } from 'react'
 import * as S from './style'
+import { XIcon } from '../../assets'
+import { ValueInputProps } from '@bitgouel/types'
 
 const ValueInput = (
   { length, onClear, errorText, isLoading, ...rest }: ValueInputProps,

--- a/shared/common/src/components/ValueInput/index.tsx
+++ b/shared/common/src/components/ValueInput/index.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useState, forwardRef, useEffect, Ref } from 'react'
-import * as S from './style'
-import { XIcon } from '../../assets'
+import { XIcon } from '@bitgouel/common'
 import { ValueInputProps } from '@bitgouel/types'
+import { Ref, forwardRef, useEffect, useState } from 'react'
+import * as S from './style'
 
 const ValueInput = (
   { length, onClear, errorText, isLoading, ...rest }: ValueInputProps,

--- a/shared/common/src/modals/AppropriationModal/index.tsx
+++ b/shared/common/src/modals/AppropriationModal/index.tsx
@@ -1,9 +1,8 @@
 'use client'
 
 import { AppropriationModalProps } from '@bitgouel/types'
-import { useModal } from '../../hooks'
-import Portal from '../../portal'
 import * as S from './style'
+import { useModal, Portal } from '@bitgouel/common'
 
 const AppropriationModal = ({
   isApprove,

--- a/shared/common/src/modals/AppropriationModal/index.tsx
+++ b/shared/common/src/modals/AppropriationModal/index.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import { AppropriationModalProps } from '@bitgouel/types'
+import { useModal } from '../../hooks'
+import Portal from '../../portal'
 import * as S from './style'
-import { useModal, Portal } from '@bitgouel/common'
 
 const AppropriationModal = ({
   isApprove,

--- a/shared/common/src/modals/InquiryAnswerModal/index.tsx
+++ b/shared/common/src/modals/InquiryAnswerModal/index.tsx
@@ -1,10 +1,12 @@
 'use client'
 
 import { usePostAnswer } from '@bitgouel/api'
-import { CancelIcon, Portal, useModal } from '@bitgouel/common'
 import { ChangeEvent, useState } from 'react'
-import AppropriationModal from '../AppropriationModal'
+import { CancelIcon } from '../../assets'
+import { useModal } from '../../hooks'
+import Portal from '../../portal'
 import * as S from './style'
+import AppropriationModal from '../AppropriationModal'
 
 const InquiryAnswerModal = ({ inquiryId }: { inquiryId: string }) => {
   const { openModal, closeModal } = useModal()

--- a/shared/common/src/modals/InquiryAnswerModal/index.tsx
+++ b/shared/common/src/modals/InquiryAnswerModal/index.tsx
@@ -1,12 +1,10 @@
 'use client'
 
 import { usePostAnswer } from '@bitgouel/api'
+import { CancelIcon, Portal, useModal } from '@bitgouel/common'
 import { ChangeEvent, useState } from 'react'
-import { CancelIcon } from '../../assets'
-import { useModal } from '../../hooks'
-import Portal from '../../portal'
-import * as S from './style'
 import AppropriationModal from '../AppropriationModal'
+import * as S from './style'
 
 const InquiryAnswerModal = ({ inquiryId }: { inquiryId: string }) => {
   const { openModal, closeModal } = useModal()

--- a/shared/common/src/pages/signUp/Pagination/SignUpScrollContainer/index.tsx
+++ b/shared/common/src/pages/signUp/Pagination/SignUpScrollContainer/index.tsx
@@ -7,7 +7,7 @@ import {
   insideJob,
   outsideJob,
   schools
-} from '@bitgouel/common'
+} from '../../../../constants'
 import * as S from './style'
 
 const SignUpScrollContainer = ({

--- a/shared/common/src/pages/signUp/Pagination/SignUpScrollContainer/index.tsx
+++ b/shared/common/src/pages/signUp/Pagination/SignUpScrollContainer/index.tsx
@@ -7,7 +7,7 @@ import {
   insideJob,
   outsideJob,
   schools
-} from '../../../../constants'
+} from '@bitgouel/common'
 import * as S from './style'
 
 const SignUpScrollContainer = ({

--- a/shared/common/tsconfig.json
+++ b/shared/common/tsconfig.json
@@ -2,10 +2,4 @@
   "extends": "@bitgouel/tsconfig/react.json",
   "include": ["**/*.ts", "**/*.tsx", "src", "src/custom.d.ts"],
   "exclude": ["node_modules"],
-  "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
-  }
 }

--- a/shared/common/tsconfig.json
+++ b/shared/common/tsconfig.json
@@ -2,4 +2,10 @@
   "extends": "@bitgouel/tsconfig/react.json",
   "include": ["**/*.ts", "**/*.tsx", "src", "src/custom.d.ts"],
   "exclude": ["node_modules"],
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
 }

--- a/shared/types/src/index.ts
+++ b/shared/types/src/index.ts
@@ -1,3 +1,2 @@
 export * from './api'
 export * from './common'
-export * from './inside'

--- a/shared/types/src/index.ts
+++ b/shared/types/src/index.ts
@@ -1,2 +1,3 @@
 export * from './api'
 export * from './common'
+export * from './inside'

--- a/shared/types/src/inside/LectureApplyModalProps.ts
+++ b/shared/types/src/inside/LectureApplyModalProps.ts
@@ -1,4 +1,0 @@
-export interface LectureApplyModalProps {
-  title: string | undefined
-  apply: () => void
-}

--- a/shared/types/src/inside/LectureApplyModalProps.ts
+++ b/shared/types/src/inside/LectureApplyModalProps.ts
@@ -1,0 +1,4 @@
+export interface LectureApplyModalProps {
+  title: string | undefined
+  apply: () => void
+}

--- a/shared/types/src/inside/index.ts
+++ b/shared/types/src/inside/index.ts
@@ -1,1 +1,0 @@
-export * from './LectureApplyModalProps'

--- a/shared/types/src/inside/index.ts
+++ b/shared/types/src/inside/index.ts
@@ -1,0 +1,1 @@
+export * from './LectureApplyModalProps'


### PR DESCRIPTION
## 💡 개요
남아있는 import를 절대경로로 변경합니다.
## 📃 작업내용
- import 상대경로 -> 절대경로 ( @bitgouel/common, @bitgouel/api )
- types폴더의 inside폴더 삭제
- 학생활동에서 사용하는 AppropriationModal에 question 수정
