### PR TITLE
interceptors, tokenManager 환경 세팅

### DIFF
--- a/packages/outside/src/PageContainer/Club/ClubPage/index.tsx
+++ b/packages/outside/src/PageContainer/Club/ClubPage/index.tsx
@@ -21,7 +21,7 @@ const ClubPage = () => {
       <SchoolFilter />
       <S.ClubWrapper>
         <S.ClubContainer>
-          {data?.data.schools.map((school) => (
+          {data?.schools.map((school) => (
             <S.ClubGroupBox key={school.id}>
               <S.ClubSchoolTitle>{school.schoolName}</S.ClubSchoolTitle>
               <S.ClubListBox>

--- a/packages/outside/src/PageContainer/Club/SchoolListPage/index.tsx
+++ b/packages/outside/src/PageContainer/Club/SchoolListPage/index.tsx
@@ -24,7 +24,7 @@ const SchoolListPage = () => {
           <S.ClubGroupBox>
             <S.ClubSchoolTitle>{schoolFilterText}</S.ClubSchoolTitle>
             <S.ClubListBox>
-              {data?.data.clubs.map((club) => (
+              {data?.clubs.map((club) => (
                 <ClubItem key={club.id} clubId={club.id} clubName={club.name} />
               ))}
             </S.ClubListBox>

--- a/shared/api/admin/club/useGetClubList.ts
+++ b/shared/api/admin/club/useGetClubList.ts
@@ -1,14 +1,14 @@
 import { clubQueryKeys, clubUrl, get } from '@bitgouel/api'
 import { ClubListResponseTypes } from '@bitgouel/types'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
-import { AxiosError, AxiosResponse } from 'axios'
+import { AxiosResponse } from 'axios'
 import { ApiError } from 'next/dist/server/api-utils'
 
 export const useGetClubList = (
   queryString: string,
-  options?: UseQueryOptions<AxiosResponse>
+  options?: UseQueryOptions<ClubListResponseTypes>
 ) =>
-  useQuery<AxiosResponse<ClubListResponseTypes>, AxiosError<ApiError>>(
+  useQuery<ClubListResponseTypes, ApiError>(
     clubQueryKeys.getClub(),
     () => get(clubUrl.club(queryString)),
     options

--- a/shared/api/admin/club/useGetSchoolClubList.ts
+++ b/shared/api/admin/club/useGetSchoolClubList.ts
@@ -5,9 +5,9 @@ import { AxiosError, AxiosResponse } from 'axios'
 import { ApiError } from 'next/dist/server/api-utils'
 
 export const useGetSchoolClubList = (
-  options?: UseQueryOptions<AxiosResponse>
+  options?: UseQueryOptions<SchoolClubListResponseTypes>
 ) =>
-  useQuery<AxiosResponse<SchoolClubListResponseTypes>, AxiosError<ApiError>>(
+  useQuery<SchoolClubListResponseTypes, ApiError>(
     clubQueryKeys.getSchoolClub(),
     () => get(clubUrl.schoolClub()),
     options

--- a/shared/api/common/src/hooks/auth/usePostLogin.ts
+++ b/shared/api/common/src/hooks/auth/usePostLogin.ts
@@ -7,20 +7,15 @@ import {
   LoginResponseTypes,
 } from '@bitgouel/types'
 import { UseMutationOptions, useMutation } from '@tanstack/react-query'
-import { AxiosError, AxiosResponse } from 'axios'
 
 export const usePostLogin = (
   options: UseMutationOptions<
-    AxiosResponse<LoginResponseTypes>,
-    AxiosError<LoginErrorTypes>,
+    LoginResponseTypes,
+    LoginErrorTypes,
     LoginPayloadTypes
   >
 ) =>
-  useMutation<
-    AxiosResponse<LoginResponseTypes>,
-    AxiosError<LoginErrorTypes>,
-    LoginPayloadTypes
-  >(
+  useMutation<LoginResponseTypes, LoginErrorTypes, LoginPayloadTypes>(
     authQueryKeys.postLogin(),
     (loginValues) => post(authUrl.login(), loginValues),
     options

--- a/shared/api/common/src/libs/api/TokenManager.ts
+++ b/shared/api/common/src/libs/api/TokenManager.ts
@@ -72,20 +72,23 @@ class TokenManager {
 
   async reissueToken() {
     try {
-      const { data }: { data: TokensTypes } = await axios.patch(
+      const { data } = await axios.patch(
         '/auth',
         {},
         {
           baseURL: '/api',
           withCredentials: true,
           headers: {
-            RefreshToken: `Bearer ${this.refreshToken}`,
+            RefreshToken:
+              this.refreshToken &&
+              `Bearer ${encodeURI(this.refreshToken || '')}`,
           },
         }
       )
+
       this.setTokens(data)
-      return true
-    } catch (e: unknown) {
+      window.location.replace(window.location.href)
+    } catch (error) {
       this.removeTokens()
       return false
     }

--- a/shared/api/common/src/libs/api/instance.ts
+++ b/shared/api/common/src/libs/api/instance.ts
@@ -45,3 +45,28 @@ instance.interceptors.request.use(
     return config
   }
 )
+
+instance.interceptors.response.use(
+  (response) => {
+    if (response.status >= 200 && response.status < 300) {
+      return response.data
+    }
+    return Promise.reject(response.data)
+  },
+  async (error) => {
+    const tokenManager = new TokenManager()
+    if (error.response.status === 401) {
+      try {
+        await tokenManager.reissueToken()
+        tokenManager.initToken()
+        error.config.headers['Authorization'] = tokenManager.accessToken
+          ? `Bearer ${encodeURI(tokenManager.accessToken)}`
+          : undefined
+        return instance(error.config)
+      } catch (err) {
+        window.location.replace('/')
+      }
+    }
+    return Promise.reject(error)
+  }
+)

--- a/shared/api/common/src/libs/api/instance.ts
+++ b/shared/api/common/src/libs/api/instance.ts
@@ -51,7 +51,6 @@ instance.interceptors.response.use(
     if (response.status >= 200 && response.status < 300) {
       return response.data
     }
-    return Promise.reject(response.data)
   },
   async (error) => {
     const tokenManager = new TokenManager()

--- a/shared/api/common/src/libs/api/instance.ts
+++ b/shared/api/common/src/libs/api/instance.ts
@@ -39,7 +39,7 @@ instance.interceptors.request.use(
       window.location.href = '/'
     }
     config.headers.Authorization = tokenManager.accessToken
-      ? `Bearer ${tokenManager.accessToken}`
+      ? `Bearer ${encodeURI(tokenManager.accessToken)}`
       : undefined
 
     return config

--- a/shared/common/src/pages/login/index.tsx
+++ b/shared/common/src/pages/login/index.tsx
@@ -29,35 +29,35 @@ const LoginPage = ({ isAdmin }: { isAdmin: boolean }) => {
   const resetPage2Obj = useResetRecoilState(SignUpPage2Obj)
   const resetPage3Obj = useResetRecoilState(SignUpPage3Obj)
   const tokenManager = new TokenManager()
-  const router = useRouter()
+  const { push } = useRouter()
   const { mutate, isLoading } = usePostLogin({
-    onSuccess: ({ data }) => {
+    onSuccess: (data) => {
       tokenManager.setTokens(data)
-      router.push('/')
+      push(`/`)
     },
     onError: (error) => {
-      if (error?.response?.status === 404) {
+      if (error.status === 404) {
         setEmailErrorText('등록되지 않은 계정입니다')
-      } else if (error?.response?.status === 403) {
+      } else if (error.status === 403) {
         setEmailErrorText('아직 회원가입 대기중인 계정입니다')
-      } else if (error?.response?.status === 401) {
+      } else if (error.status === 401) {
         setPasswordErrorText('비밀번호가 일치하지 않습니다')
-      } else if (error?.response?.status === 400) {
+      } else if (error.status === 400) {
         if (
-          Object.keys(error.response?.data.fieldError).includes('email') &&
-          Object.keys(error.response?.data.fieldError).includes('password')
+          Object.keys(error.fieldError).includes('email') &&
+          Object.keys(error.fieldError).includes('password')
         ) {
           setEmailErrorText('잘못된 이메일입니다')
           setPasswordErrorText('잘못된 비밀번호입니다')
         } else if (
-          Object.keys(error.response?.data.fieldError).includes('email') &&
-          !Object.keys(error.response?.data.fieldError).includes('password')
+          Object.keys(error.fieldError).includes('email') &&
+          !Object.keys(error.fieldError).includes('password')
         ) {
           setEmailErrorText('잘못된 이메일입니다.')
           setPasswordErrorText('')
         } else if (
-          Object.keys(error.response?.data.fieldError).includes('password') &&
-          !Object.keys(error.response?.data.fieldError).includes('email')
+          Object.keys(error.fieldError).includes('password') &&
+          !Object.keys(error.fieldError).includes('email')
         ) {
           setPasswordErrorText('잘못된 비밀번호입니다.')
           setEmailErrorText('')
@@ -91,7 +91,7 @@ const LoginPage = ({ isAdmin }: { isAdmin: boolean }) => {
     resetPage1Obj()
     resetPage2Obj()
     resetPage3Obj()
-    router.push('/auth/signUp')
+    push(`/auth/signUp`)
   }
 
   return (


### PR DESCRIPTION
## 💡 배경 및 개요

> axios data 접근을 2번을 하여 필요하지 않는 데이터 접근을 계속 하여 효율성이 떨어졌습니다.
> refresh 토큰 발급 로직 추가

## 📃 작업내용

> axios data를 instance에서 설정하여서 res.data로 구조분해할당을 해서 넘겨줍니다. 이로 data.(reponse data)로 접근이 가능합니다. 
> Query hooks에서 AxiosResponse, Error를 제외한, 다른 Types를 지정시 사용이 가능합니다. (참고)

## 🎸 기타
