### PR TITLE
[Common] 강의 상세 날짜 포맷

### DIFF
--- a/shared/common/src/pages/lecture/detail/index.tsx
+++ b/shared/common/src/pages/lecture/detail/index.tsx
@@ -38,16 +38,8 @@ const LectureDetailPage = ({ lectureId }: { lectureId: string }) => {
         <S.Document>
           <S.TitleContainer>
             <S.LectureStatusContainer>
-              <S.LectureStatusBox>
-                {
-                  lectureTypeToKor[
-                    data?.lectureType || 'MUTUAL_CREDIT_RECOGNITION_PROGRAM'
-                  ]
-                }
-              </S.LectureStatusBox>
-              <S.LectureStatusBox>
-                {lectureDivisionToKor[data?.division || 'AI_CONVERGENCE']}
-              </S.LectureStatusBox>
+              <S.LectureStatusBox>{data?.lectureType}</S.LectureStatusBox>
+              <S.LectureStatusBox>{data?.division}</S.LectureStatusBox>
             </S.LectureStatusContainer>
             <h1>{data?.name}</h1>
             <S.LectureInfoContainer>
@@ -59,18 +51,22 @@ const LectureDetailPage = ({ lectureId }: { lectureId: string }) => {
           <S.LectureDateWrapper>
             <h2>수강 신청 기간</h2>
             <S.LectureDateText>
-              • {dayjs(data?.startDate).format('YYYY년 MM월 DD일 HH시 mm분')}
-              {'  '}~{'  '}•{' '}
+              • {dayjs(data?.startDate).format('YYYY년 MM월 DD일 HH시 mm분')} ~{' '}
               {dayjs(data?.endDate).format('YYYY년 MM월 DD일 HH시 mm분')}
             </S.LectureDateText>
           </S.LectureDateWrapper>
           <S.LectureDateWrapper>
             <h2>강의 수강 날짜</h2>
-            {data?.lectureDates.map((date) => (
-              <S.LectureDateText>
-                • {dayjs(date.completeDate).format('YYYY년 MM월 DD일')}~
-                {dayjs(date.endTime).format('HH시 mm분')}
-                {dayjs(date.startTime).format('HH시 mm분')}
+            {data?.lectureDates.map((date, idx) => (
+              <S.LectureDateText key={idx}>
+                • {dayjs(date.completeDate).format('YYYY년 MM월 DD일')}{' '}
+                {dayjs(`${date.completeDate}T${date.startTime}`).format(
+                  'HH시 mm분'
+                )}{' '}
+                ~{' '}
+                {dayjs(`${date.completeDate}T${date.endTime}`).format(
+                  'HH시 mm분'
+                )}
               </S.LectureDateText>
             ))}
           </S.LectureDateWrapper>


### PR DESCRIPTION
## 💡 배경 및 개요
강의 상세에서 날짜 포맷 시 dayjs 라이브러리 규칙에 맞지 않아 다음과 같은 화면이 보입니다.
<img width="578" alt="image" src="https://github.com/GSM-MSG/Bitgouel-Frontend/assets/105215297/36ad577c-5b86-41db-b0c0-7f2fd6a74ad6">


## 📃 작업내용
- completeDate와 각각 startTime, endTime을 합쳐 날짜를 포맷
<img width="604" alt="image" src="https://github.com/GSM-MSG/Bitgouel-Frontend/assets/105215297/10115610-7261-4e69-a18a-e938f86270b5">

## ✅ PR 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
작업 화면에서 시간이 똑같은 건 테스트 데이터라 그렇습니다.