### PR TITLE
[Inside, Common] PrivateRouter 특정 페이지에 적용

### DIFF
--- a/packages/inside/src/PageContainer/Club/ActivityWritePage/index.tsx
+++ b/packages/inside/src/PageContainer/Club/ActivityWritePage/index.tsx
@@ -9,6 +9,7 @@ import {
   AppropriationModal,
   Bg2,
   Chevron,
+  PrivateRouter,
   SelectCalendarModal,
   SelectScoreModal,
   useModal,
@@ -160,6 +161,7 @@ const ActivityWritePage = ({
   }, [data])
 
   return (
+    <PrivateRouter>
     <div>
       <S.SlideBg url={Bg2}>
         <S.BgContainer>
@@ -239,6 +241,7 @@ const ActivityWritePage = ({
         </S.DocumentInput>
       </S.DocumentInputContainer>
     </div>
+    </PrivateRouter>
   )
 }
 export default ActivityWritePage

--- a/shared/common/src/pages/activity/detail/index.tsx
+++ b/shared/common/src/pages/activity/detail/index.tsx
@@ -9,6 +9,7 @@ import {
   AppropriationModal,
   Bg2,
   Pen,
+  PrivateRouter,
   TrashCan,
   useModal,
 } from '@bitgouel/common'
@@ -36,6 +37,7 @@ const ActivityDetailPage: React.FC<ActivityDetailProps> = ({
   }, [])
 
   return (
+    <PrivateRouter>
     <div>
       <S.SlideBg url={Bg2}>
         <S.BgContainer>
@@ -106,6 +108,7 @@ const ActivityDetailPage: React.FC<ActivityDetailProps> = ({
         </S.Document>
       </S.DocumentWrapper>
     </div>
+    </PrivateRouter>
   )
 }
 

--- a/shared/common/src/pages/activity/list/index.tsx
+++ b/shared/common/src/pages/activity/list/index.tsx
@@ -6,7 +6,7 @@ import {
   useGetActivityMyselfList,
   useGetStudentDetail,
 } from '@bitgouel/api'
-import { ActivityItem, Bg2, Plus } from '@bitgouel/common'
+import { ActivityItem, Bg2, Plus, PrivateRouter } from '@bitgouel/common'
 import { StudentIdProps } from '@bitgouel/types'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
@@ -35,6 +35,7 @@ const ActivityListPage: React.FC<Props> = ({ studentIdProps }) => {
   }, [])
 
   return (
+    <PrivateRouter>
     <div>
       <S.SlideBg url={Bg2}>
         <S.BgContainer>
@@ -68,6 +69,7 @@ const ActivityListPage: React.FC<Props> = ({ studentIdProps }) => {
         </S.ActivityContainer>
       </S.ActivityWrapper>
     </div>
+    </PrivateRouter>
   )
 }
 

--- a/shared/common/src/pages/lecture/apply/index.tsx
+++ b/shared/common/src/pages/lecture/apply/index.tsx
@@ -1,11 +1,9 @@
 'use client'
 
-import { LectureApplyItem, Bg3, handleSelect } from '@bitgouel/common'
-import { useEffect, useState } from 'react'
-import * as S from './style'
 import { TokenManager, useGetLectureApplyList } from '@bitgouel/api'
+import { Bg3, LectureApplyItem, PrivateRouter } from '@bitgouel/common'
 import { RoleEnumTypes } from '@bitgouel/types'
-import { redirect } from 'next/navigation'
+import * as S from './style'
 
 const roleArray: RoleEnumTypes[] = [
   'ROLE_ADMIN',
@@ -17,17 +15,10 @@ const roleArray: RoleEnumTypes[] = [
 ]
 
 const LectureApplyListPage = ({ lectureId }: { lectureId: string }) => {
-  const tokenManager = new TokenManager()
   const { data } = useGetLectureApplyList(lectureId)
 
-  useEffect(() => {
-    if (tokenManager.authority) {
-      if (tokenManager && roleArray.includes(tokenManager.authority)) return
-      else return redirect('/')
-    }
-  }, [])
-
   return (
+    <PrivateRouter>
     <div>
       <S.SlideBg url={Bg3}>
         <S.BgContainer>
@@ -53,6 +44,7 @@ const LectureApplyListPage = ({ lectureId }: { lectureId: string }) => {
         )} */}
       </S.ListWrapper>
     </div>
+    </PrivateRouter>
   )
 }
 

--- a/shared/common/src/pages/lecture/create/index.tsx
+++ b/shared/common/src/pages/lecture/create/index.tsx
@@ -20,7 +20,8 @@ import {
   LectureStartDate,
   LectureStartTime,
   LectureType,
-  useModal,
+  PrivateRouter,
+  useModal
 } from '@bitgouel/common'
 import { useRouter } from 'next/navigation'
 import { ChangeEvent, useState } from 'react'
@@ -130,7 +131,8 @@ const LectureCreatePage = () => {
   }
 
   return (
-    <div>
+    <PrivateRouter>
+      <div>
       <S.SlideBg url={Bg3}>
         <S.BgContainer>
           <S.CreateTitle>강의 개설</S.CreateTitle>
@@ -165,7 +167,8 @@ const LectureCreatePage = () => {
           </S.CreateButton>
         </S.DocumentInput>
       </S.DocumentInputContainer>
-    </div>
+      </div>
+    </PrivateRouter>
   )
 }
 

--- a/shared/common/src/pages/post/write/index.tsx
+++ b/shared/common/src/pages/post/write/index.tsx
@@ -5,7 +5,7 @@ import {
   usePatchPostModify,
   usePostPost,
 } from '@bitgouel/api'
-import { AppropriationModal, Bg1, Link, useModal } from '@bitgouel/common'
+import { AppropriationModal, Bg1, Link, PrivateRouter, useModal } from '@bitgouel/common'
 import { LinksObjectTypes } from '@bitgouel/types'
 import { ChangeEvent, useEffect, useState } from 'react'
 import * as S from './style'
@@ -109,6 +109,7 @@ const PostWritePage = ({ postId }: { postId?: string }) => {
   }
 
   return (
+    <PrivateRouter>
     <div>
       <S.SlideBg url={Bg1}>
         <S.BgContainer>
@@ -159,6 +160,7 @@ const PostWritePage = ({ postId }: { postId?: string }) => {
         </S.DocumentInput>
       </S.DocumentInputContainer>
     </div>
+    </PrivateRouter>
   )
 }
 


### PR DESCRIPTION
## 💡 배경 및 개요
제작한 PrivateRouter를 관리자나 클라이언트 권한이 섞인 페이지들에 적용시켜야합니다.

## 📃 작업내용
- 특정 페이지 컴포넌트의 return의 jsx를 PrivateRouter로 감싸기

## ✅ PR 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?