### PR TITLE
[Admin] 학교 선택 필터 refresh 상태 유지, hydration Error conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "next": "13.4.2",
     "react-toastify": "^9.1.3",
     "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0",
     "ts-pattern": "^5.0.5"
   }
 }

--- a/packages/outside/src/PageContainer/Club/SchoolListPage/index.tsx
+++ b/packages/outside/src/PageContainer/Club/SchoolListPage/index.tsx
@@ -7,32 +7,36 @@ import {
   schoolToConstants,
   MainStyle,
 } from '@bitgouel/common'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useRecoilValue } from 'recoil'
 import * as S from '../ClubPage/style'
 
 const SchoolListPage = () => {
+  const [isClient, setIsClient] = useState<boolean>(false)
   const schoolFilterText = useRecoilValue(SchoolFilterText)
   const { data, refetch } = useGetClubList(schoolToConstants[schoolFilterText])
 
   useEffect(() => {
     refetch()
+    setIsClient(true)
   }, [schoolFilterText])
 
   return (
-    <MainStyle.PageWrapper>
-      <SchoolFilter />
-      <MainStyle.MainWrapper>
-        <MainStyle.MainContainer>
-          <S.ClubSchoolTitle>{schoolFilterText}</S.ClubSchoolTitle>
-          <S.ClubListWrapper>
-            {data?.clubs.map((club) => (
-              <ClubItem key={club.id} clubId={club.id} clubName={club.name} />
-            ))}
-          </S.ClubListWrapper>
-        </MainStyle.MainContainer>
-      </MainStyle.MainWrapper>
-    </MainStyle.PageWrapper>
+    isClient && (
+      <MainStyle.PageWrapper>
+        <SchoolFilter />
+        <MainStyle.MainWrapper>
+          <MainStyle.MainContainer>
+            <S.ClubSchoolTitle>{schoolFilterText}</S.ClubSchoolTitle>
+            <S.ClubListWrapper>
+              {data?.clubs.map((club) => (
+                <ClubItem key={club.id} clubId={club.id} clubName={club.name} />
+              ))}
+            </S.ClubListWrapper>
+          </MainStyle.MainContainer>
+        </MainStyle.MainWrapper>
+      </MainStyle.PageWrapper>
+    )
   )
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       recoil:
         specifier: ^0.7.7
         version: 0.7.7(react-dom@18.2.0)(react@18.2.0)
+      recoil-persist:
+        specifier: ^5.1.0
+        version: 5.1.0(recoil@0.7.7)
       ts-pattern:
         specifier: ^5.0.5
         version: 5.0.5
@@ -3905,6 +3908,8 @@ packages:
       webpack: ^5.0.0
     peerDependenciesMeta:
       '@next/font':
+        optional: true
+      '@storybook/addon-actions':
         optional: true
       typescript:
         optional: true
@@ -9064,6 +9069,14 @@ packages:
       source-map: 0.6.1
       tslib: 2.6.2
     dev: true
+
+  /recoil-persist@5.1.0(recoil@0.7.7):
+    resolution: {integrity: sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==}
+    peerDependencies:
+      recoil: ^0.7.2
+    dependencies:
+      recoil: 0.7.7(react-dom@18.2.0)(react@18.2.0)
+    dev: false
 
   /recoil@0.7.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==}

--- a/shared/common/src/atoms/index.ts
+++ b/shared/common/src/atoms/index.ts
@@ -7,6 +7,15 @@ import {
 } from '@bitgouel/types'
 import { ReactNode } from 'react'
 import { atom } from 'recoil'
+import { recoilPersist } from 'recoil-persist'
+
+const sessionStorage =
+  typeof window !== 'undefined' ? window.sessionStorage : undefined
+
+const { persistAtom } = recoilPersist({
+  key: 'recoil-states',
+  storage: sessionStorage,
+})
 
 interface InputLectureDatesTypes extends LectureDate {
   startShowTime: string
@@ -166,4 +175,5 @@ export const LectureCredit = atom<1 | 2>({
 export const SchoolFilterText = atom<string>({
   key: 'SchoolFilterText',
   default: '',
+  effects_UNSTABLE: [persistAtom],
 })


### PR DESCRIPTION
## 💡 배경 및 개요

> 기존에 Admin SchoolFilter에서 refresh 시 사라지는 Recoil Value 값을 refesh 이후에도 동작하게 설정하였습니다.

## 📃 작업내용

> recoil-persist Next 설정
> page component에서 발생하는 Next Hydration error 해결
## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
