### PR TITLE
[Common] 게시물 관련 페이지 수정하기 버튼 조건 추가

### DIFF
--- a/shared/common/src/components/Auth/Login/LoginForm/index.tsx
+++ b/shared/common/src/components/Auth/Login/LoginForm/index.tsx
@@ -8,7 +8,7 @@ import {
   PasswordErrorText,
   PasswordValue,
 } from '@bitgouel/common'
-import { LoginErrorTypes, LoginPayloadTypes } from '@bitgouel/types'
+import { LoginPayloadTypes } from '@bitgouel/types'
 import { useRouter } from 'next/navigation'
 import { toast } from 'react-toastify'
 import { useRecoilValue, useSetRecoilState } from 'recoil'

--- a/shared/common/src/pages/post/detail/index.tsx
+++ b/shared/common/src/pages/post/detail/index.tsx
@@ -70,28 +70,31 @@ const PostDetailPage = ({ postId }: { postId: string }) => {
           </S.LinkTextBox>
           <S.ButtonWrapper>
             <S.ButtonContainer>
-              {isRole && (
-                <S.DeletePostButton
-                  onClick={() =>
-                    openModal(
-                      <AppropriationModal
-                        isApprove={false}
-                        question='게시글을 삭제하시겠습니까?'
-                        purpose='삭제하기'
-                        title={data?.title || ''}
-                        onAppropriation={() => mutate()}
-                      />
-                    )
-                  }
-                >
-                  삭제하기
-                </S.DeletePostButton>
+               {isRole && (
+                <>
+                  <S.DeletePostButton
+                    onClick={() =>
+                      openModal(
+                        <AppropriationModal
+                          isApprove={false}
+                          question='게시글을 삭제하시겠습니까?'
+                          purpose='삭제하기'
+                          title={data?.title || ''}
+                          onAppropriation={() => mutate()}
+                        />
+                      )
+                    }
+                  >
+                    삭제하기
+                  </S.DeletePostButton>
+
+                  <S.ModifyPostButton
+                    onClick={() => push(`/main/post/${postId}/modify`)}
+                  >
+                    수정하기
+                  </S.ModifyPostButton>
+                </>
               )}
-              <S.ModifyPostButton
-                onClick={() => push(`/main/post/${postId}/modify`)}
-              >
-                수정하기
-              </S.ModifyPostButton>
             </S.ButtonContainer>
           </S.ButtonWrapper>
         </MainStyle.MainContainer>


### PR DESCRIPTION
## 💡 배경 및 개요
게시물 페이지 상세에서 특정 권한이 아닌데도 수정할 수 있는 버튼이 생겼습니다.

## 📃 작업내용
- 게시물 페이지에 특정권한일 때 렌더링 조건에 수정하기 버튼도 포함

## ✅ PR 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?