### PR TITLE
[Common] 회원가입 submit 이벤트 추가

### DIFF
--- a/shared/common/src/hooks/index.ts
+++ b/shared/common/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useModal } from './useModal'
 export { default as useFilterSelect } from './useFilterSelect'
-export { default as  useIntersectionObserver } from './useIntersectionObserver'
+export { default as useIntersectionObserver } from './useIntersectionObserver'
+export { default as useSignUp } from './useSignUp'

--- a/shared/common/src/hooks/useSignUp.tsx
+++ b/shared/common/src/hooks/useSignUp.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import {
+  usePostSignUpBbozzak,
+  usePostSignUpCompanyInstructor,
+  usePostSignUpGovernment,
+  usePostSignUpProfessor,
+  usePostSignUpStudent,
+  usePostSignUpTeacher,
+} from '@bitgouel/api'
+import {
+  SignUpPage1Obj,
+  SignUpPage2Obj,
+  SignUpPage3Obj,
+  SignUpPageNumber,
+  schoolToConstants,
+} from '@bitgouel/common'
+import { SignUpCommonPayloadTypes } from '@bitgouel/types'
+import { toast } from 'react-toastify'
+import { useRecoilState, useRecoilValue } from 'recoil'
+
+const useSignUp = ({ isNext }: { isNext: boolean }) => {
+  const signUpPage1Obj = useRecoilValue(SignUpPage1Obj)
+  const [signUpPage2Obj, setSignUpPage2Obj] = useRecoilState(SignUpPage2Obj)
+  const signUpPage3Obj = useRecoilValue(SignUpPage3Obj)
+  const [signUpPageNumber, setSignUpPageNumber] =
+    useRecoilState(SignUpPageNumber)
+
+  const onSuccess = () => setSignUpPageNumber(4)
+  const onError = (error) =>
+    toast.error(error?.response.data.message.split('.')[0])
+
+  const signUpMutate = {
+    student: usePostSignUpStudent({ onSuccess, onError }),
+    teacher: usePostSignUpTeacher({ onSuccess, onError }),
+    bbozzak: usePostSignUpBbozzak({ onSuccess, onError }),
+    professor: usePostSignUpProfessor({ onSuccess, onError }),
+    government: usePostSignUpGovernment({ onSuccess, onError }),
+    companyInstructor: usePostSignUpCompanyInstructor({
+      onSuccess,
+      onError,
+    }),
+  }
+
+  const { mutate: postStudent } = signUpMutate.student
+  const { mutate: postTeacher } = signUpMutate.teacher
+  const { mutate: postBbozzak } = signUpMutate.bbozzak
+  const { mutate: postProfessor } = signUpMutate.professor
+  const { mutate: postGovernment } = signUpMutate.government
+  const { mutate: postCompanyInstructor } = signUpMutate.companyInstructor
+
+  const onNext = () => {
+    if (isNext) {
+      if (signUpPageNumber === 1) {
+        setSignUpPage2Obj((prev) => prev.slice(0, 3))
+        if (signUpPage1Obj[1].value === '학생') {
+          setSignUpPage2Obj((prev) => [
+            ...prev,
+            {
+              value: '',
+              placeholder: '입학년도 선택',
+              type: 'number',
+              maxLength: 4,
+              pattern: '2021|2022|2023|2024',
+            },
+            {
+              value: '',
+              placeholder: '학번 입력 (ex:1101)',
+              type: 'number',
+              maxLength: 5,
+            },
+          ])
+        } else if (
+          signUpPage1Obj[1].value === '취업동아리 선생님' ||
+          signUpPage1Obj[1].value === '취업뽀짝 선생님'
+        ) {
+          setSignUpPage2Obj((prev) => prev)
+        } else if (signUpPage1Obj[1].value === '기업 강사') {
+          setSignUpPage2Obj((prev) => [
+            ...prev,
+            { value: '', placeholder: '소속 기업명 입력', type: 'text' },
+          ])
+        } else if (signUpPage1Obj[1].value === '대학 교수') {
+          setSignUpPage2Obj((prev) => [
+            ...prev,
+            { value: '', placeholder: '대학명 입력', type: 'text' },
+          ])
+        } else if (signUpPage1Obj[1].value === '유관기관') {
+          setSignUpPage2Obj((prev) => [
+            ...prev,
+            { value: '', placeholder: '소속 기관명 입력', type: 'text' },
+            { value: '', placeholder: '본인의 직책 입력', type: 'text' },
+            { value: '', placeholder: '소속 기관의 업종 입력', type: 'text' },
+          ])
+        }
+        setSignUpPageNumber((prev) => prev + 1)
+      } else if (signUpPageNumber === 2) setSignUpPageNumber((prev) => prev + 1)
+      else if (signUpPageNumber === 3) {
+        if (signUpPage1Obj[1].value === '학생') {
+          postStudent({
+            ...commonPayload,
+            grade: +signUpPage2Obj[4].value.slice(0, 1),
+            classRoom: +signUpPage2Obj[4].value.slice(1, 2),
+            number: +signUpPage2Obj[4].value.slice(2),
+            admissionNumber: +signUpPage2Obj[3].value,
+          })
+        } else if (signUpPage1Obj[1].value === '취업동아리 선생님') {
+          postTeacher(commonPayload)
+        } else if (signUpPage1Obj[1].value === '뽀짝 선생님') {
+          postBbozzak(commonPayload)
+        } else if (signUpPage1Obj[1].value === '대학 교수') {
+          postProfessor({
+            ...commonPayload,
+            university: signUpPage2Obj[3].value,
+          })
+        } else if (signUpPage1Obj[1].value === '유관기관') {
+          postGovernment({
+            ...commonPayload,
+            governmentName: signUpPage2Obj[3].value,
+            position: signUpPage2Obj[4].value,
+            sectors: signUpPage2Obj[5].value,
+          })
+        } else if (signUpPage1Obj[1].value === '기업 강사') {
+          postCompanyInstructor({
+            ...commonPayload,
+            company: signUpPage2Obj[3].value,
+          })
+        }
+      }
+    }
+  }
+
+  const commonPayload: SignUpCommonPayloadTypes = {
+    email: signUpPage3Obj[1].value,
+    name: signUpPage2Obj[2].value,
+    phoneNumber: signUpPage3Obj[0].value,
+    password: signUpPage3Obj[2].value,
+    highSchool: schoolToConstants[signUpPage2Obj[0].value],
+    clubName: signUpPage2Obj[1].value,
+  }
+
+  return [onNext]
+}
+
+export default useSignUp

--- a/shared/common/src/hooks/useSignUp.tsx
+++ b/shared/common/src/hooks/useSignUp.tsx
@@ -49,6 +49,15 @@ const useSignUp = ({ isNext }: { isNext: boolean }) => {
   const { mutate: postGovernment } = signUpMutate.government
   const { mutate: postCompanyInstructor } = signUpMutate.companyInstructor
 
+  const commonPayload: SignUpCommonPayloadTypes = {
+    email: signUpPage3Obj[1].value,
+    name: signUpPage2Obj[2].value,
+    phoneNumber: signUpPage3Obj[0].value,
+    password: signUpPage3Obj[2].value,
+    highSchool: schoolToConstants[signUpPage2Obj[0].value],
+    clubName: signUpPage2Obj[1].value,
+  }
+
   const onNext = () => {
     if (isNext) {
       if (signUpPageNumber === 1) {
@@ -128,15 +137,6 @@ const useSignUp = ({ isNext }: { isNext: boolean }) => {
         }
       }
     }
-  }
-
-  const commonPayload: SignUpCommonPayloadTypes = {
-    email: signUpPage3Obj[1].value,
-    name: signUpPage2Obj[2].value,
-    phoneNumber: signUpPage3Obj[0].value,
-    password: signUpPage3Obj[2].value,
-    highSchool: schoolToConstants[signUpPage2Obj[0].value],
-    clubName: signUpPage2Obj[1].value,
   }
 
   return [onNext]

--- a/shared/common/src/pages/auth/signUp/SignUpPages/SignUpButtonContainer/index.tsx
+++ b/shared/common/src/pages/auth/signUp/SignUpPages/SignUpButtonContainer/index.tsx
@@ -1,24 +1,8 @@
 'use client'
 
-import {
-  usePostSignUpBbozzak,
-  usePostSignUpCompanyInstructor,
-  usePostSignUpGovernment,
-  usePostSignUpProfessor,
-  usePostSignUpStudent,
-  usePostSignUpTeacher,
-} from '@bitgouel/api'
-import {
-  SignUpPage1Obj,
-  SignUpPage2Obj,
-  SignUpPage3Obj,
-  SignUpPageNumber,
-  schoolToConstants,
-} from '@bitgouel/common'
-import { SignUpCommonPayloadTypes } from '@bitgouel/types'
+import { SignUpPageNumber, useSignUp } from '@bitgouel/common'
 import { useRouter } from 'next/navigation'
-import { toast } from 'react-toastify'
-import { useRecoilState, useRecoilValue } from 'recoil'
+import { useRecoilState } from 'recoil'
 import { match } from 'ts-pattern'
 import * as S from './style'
 
@@ -26,134 +10,12 @@ const SignUpButtonContainer = ({ isNext }: { isNext: boolean }) => {
   const { push } = useRouter()
   const [signUpPageNumber, setSignUpPageNumber] =
     useRecoilState(SignUpPageNumber)
-  const signUpPage1Obj = useRecoilValue(SignUpPage1Obj)
-  const [signUpPage2Obj, setSignUpPage2Obj] = useRecoilState(SignUpPage2Obj)
-  const signUpPage3Obj = useRecoilValue(SignUpPage3Obj)
-
-  const commonPayload: SignUpCommonPayloadTypes = {
-    email: signUpPage3Obj[1].value,
-    name: signUpPage2Obj[2].value,
-    phoneNumber: signUpPage3Obj[0].value,
-    password: signUpPage3Obj[2].value,
-    highSchool: schoolToConstants[signUpPage2Obj[0].value],
-    clubName: signUpPage2Obj[1].value,
-  }
-
-  const { mutate: postStudent } = usePostSignUpStudent({
-    onSuccess: () => setSignUpPageNumber(4),
-    onError: ({ response }) =>
-      toast.error(response?.data.message.split('.')[0]),
-  })
-  const { mutate: postTeacher } = usePostSignUpTeacher({
-    onSuccess: () => setSignUpPageNumber(4),
-    onError: ({ response }) =>
-      toast.error(response?.data.message.split('.')[0]),
-  })
-  const { mutate: postBbozzak } = usePostSignUpBbozzak({
-    onSuccess: () => setSignUpPageNumber(4),
-    onError: ({ response }) =>
-      toast.error(response?.data.message.split('.')[0]),
-  })
-  const { mutate: postProfessor } = usePostSignUpProfessor({
-    onSuccess: () => setSignUpPageNumber(4),
-    onError: ({ response }) =>
-      toast.error(response?.data.message.split('.')[0]),
-  })
-  const { mutate: postGovernment } = usePostSignUpGovernment({
-    onSuccess: () => setSignUpPageNumber(4),
-    onError: ({ response }) =>
-      toast.error(response?.data.message.split('.')[0]),
-  })
-  const { mutate: postCompanyInstructor } = usePostSignUpCompanyInstructor({
-    onSuccess: () => setSignUpPageNumber(4),
-    onError: ({ response }) =>
-      toast.error(response?.data.message.split('.')[0]),
-  })
-
-  const onNext = () => {
-    if (isNext) {
-      if (signUpPageNumber === 1) {
-        setSignUpPage2Obj((prev) => prev.slice(0, 3))
-        if (signUpPage1Obj[1].value === '학생') {
-          setSignUpPage2Obj((prev) => [
-            ...prev,
-            {
-              value: '',
-              placeholder: '입학년도 선택',
-              type: 'number',
-              maxLength: 4,
-              pattern: '2021|2022|2023|2024',
-            },
-            {
-              value: '',
-              placeholder: '학번 입력 (ex:1101)',
-              type: 'number',
-              maxLength: 5,
-            },
-          ])
-        } else if (
-          signUpPage1Obj[1].value === '취업동아리 선생님' ||
-          signUpPage1Obj[1].value === '취업뽀짝 선생님'
-        ) {
-          setSignUpPage2Obj((prev) => prev)
-        } else if (signUpPage1Obj[1].value === '기업 강사') {
-          setSignUpPage2Obj((prev) => [
-            ...prev,
-            { value: '', placeholder: '소속 기업명 입력', type: 'text' },
-          ])
-        } else if (signUpPage1Obj[1].value === '대학 교수') {
-          setSignUpPage2Obj((prev) => [
-            ...prev,
-            { value: '', placeholder: '대학명 입력', type: 'text' },
-          ])
-        } else if (signUpPage1Obj[1].value === '유관기관') {
-          setSignUpPage2Obj((prev) => [
-            ...prev,
-            { value: '', placeholder: '소속 기관명 입력', type: 'text' },
-            { value: '', placeholder: '본인의 직책 입력', type: 'text' },
-            { value: '', placeholder: '소속 기관의 업종 입력', type: 'text' },
-          ])
-        }
-        setSignUpPageNumber((prev) => prev + 1)
-      } else if (signUpPageNumber === 2) setSignUpPageNumber((prev) => prev + 1)
-      else if (signUpPageNumber === 3) {
-        if (signUpPage1Obj[1].value === '학생') {
-          postStudent({
-            ...commonPayload,
-            grade: +signUpPage2Obj[4].value.slice(0, 1),
-            classRoom: +signUpPage2Obj[4].value.slice(1, 2),
-            number: +signUpPage2Obj[4].value.slice(2),
-            admissionNumber: +signUpPage2Obj[3].value,
-          })
-        } else if (signUpPage1Obj[1].value === '취업동아리 선생님') {
-          postTeacher(commonPayload)
-        } else if (signUpPage1Obj[1].value === '뽀짝 선생님') {
-          postBbozzak(commonPayload)
-        } else if (signUpPage1Obj[1].value === '대학 교수') {
-          postProfessor({
-            ...commonPayload,
-            university: signUpPage2Obj[3].value,
-          })
-        } else if (signUpPage1Obj[1].value === '유관기관') {
-          postGovernment({
-            ...commonPayload,
-            governmentName: signUpPage2Obj[3].value,
-            position: signUpPage2Obj[4].value,
-            sectors: signUpPage2Obj[5].value,
-          })
-        } else if (signUpPage1Obj[1].value === '기업 강사') {
-          postCompanyInstructor({
-            ...commonPayload,
-            company: signUpPage2Obj[3].value,
-          })
-        }
-      }
-    }
-  }
+  const [onNext] = useSignUp({ isNext })
 
   return (
     <S.SignUpButtonContainer page={signUpPageNumber}>
       <S.PreButton
+        type='button'
         onClick={() =>
           match(signUpPageNumber)
             .with(1, () => push('/auth/login'))
@@ -162,7 +24,7 @@ const SignUpButtonContainer = ({ isNext }: { isNext: boolean }) => {
       >
         이전으로
       </S.PreButton>
-      <S.NextButton isNext={isNext} onClick={onNext}>
+      <S.NextButton type='submit' isNext={isNext} onClick={onNext}>
         {signUpPageNumber !== 3 ? '다음으로' : '가입하기'}
       </S.NextButton>
     </S.SignUpButtonContainer>

--- a/shared/common/src/pages/auth/signUp/index.tsx
+++ b/shared/common/src/pages/auth/signUp/index.tsx
@@ -3,6 +3,9 @@
 import { SignUpPage1Obj, SignUpPage2Obj, SignUpPage3Obj, SignUpPageNumber, useSignUp } from '@bitgouel/common'
 import { FormEvent } from 'react'
 import { useRecoilValue } from 'recoil'
+import AuthTitleMenu from '../AuthTitleMenu'
+import { AuthWrapper } from '../style'
+import { SignUpPage1, SignUpPage2, SignUpPage3, SignUpSuccess } from './SignUpPages'
 import * as S from './style'
 
 const mainTitleList = ['만나서 반가워요!', '회원가입을 진행합니다', '얼마 안 남았어요!']

--- a/shared/common/src/pages/auth/signUp/index.tsx
+++ b/shared/common/src/pages/auth/signUp/index.tsx
@@ -1,15 +1,8 @@
 'use client'
 
-import { SignUpPageNumber } from '@bitgouel/common'
+import { SignUpPage1Obj, SignUpPage2Obj, SignUpPage3Obj, SignUpPageNumber, useSignUp } from '@bitgouel/common'
+import { FormEvent } from 'react'
 import { useRecoilValue } from 'recoil'
-import AuthTitleMenu from '../AuthTitleMenu'
-import { AuthWrapper } from '../style'
-import {
-  SignUpPage1,
-  SignUpPage2,
-  SignUpPage3,
-  SignUpSuccess,
-} from './SignUpPages'
 import * as S from './style'
 
 const mainTitleList = ['만나서 반가워요!', '회원가입을 진행합니다', '얼마 안 남았어요!']
@@ -17,13 +10,30 @@ const subTitleList = ['어디서 오셨나요?', '본인의 인적 사항을 입
 
 const SignUpPage = () => {
   const signUpPage = useRecoilValue(SignUpPageNumber)
+  const signUpPage1Obj = useRecoilValue(SignUpPage1Obj)
+  const signUpPage2Obj = useRecoilValue(SignUpPage2Obj)
+  const signUpPage3Obj = useRecoilValue(SignUpPage3Obj)
+
+  const isNextPage = {
+    1: signUpPage1Obj.every((item) => item.value.length),
+    2: signUpPage2Obj.every((item) => item.value.length),
+    3: signUpPage3Obj.every((item) => item.value.length)
+  }
+
+  const [onNext] = useSignUp({ isNext: isNextPage[signUpPage] })
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    onNext()
+  }
+
   return (
     <>
       {signUpPage === 4 && <SignUpSuccess />}
       {signUpPage < 4 && (
         <AuthWrapper>
           <AuthTitleMenu matchEl={signUpPage} mainTitleList={mainTitleList} subTitleList={subTitleList} />
-          <S.SignUpFormContainer>
+          <S.SignUpFormContainer onSubmit={onSubmit}>
             {signUpPage === 1 && <SignUpPage1 />}
             {signUpPage === 2 && <SignUpPage2 />}
             {signUpPage === 3 && <SignUpPage3 />}

--- a/shared/common/src/pages/auth/signUp/style.ts
+++ b/shared/common/src/pages/auth/signUp/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 
-export const SignUpFormContainer = styled.div`
+export const SignUpFormContainer = styled.form`
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## 💡 배경 및 개요
회원가입에서 입력을 완료하면 엔터로 넘어갈 수 있으면 좋겠다는 요청이 들어왔습니다.

## 📃 작업내용
- 버튼을 클릭하는 것과 submit 두 이벤트에 동일한 함수를 전달해야 하기에 custom hooks로 추상화
- 권한 별 회원가입 코드 간소화
- SignUpFormContainer form 태그로 변경

## 🙋‍♂️ 리뷰노트
간단한 작업임에도 코드 간의 의존도가 많이 높아서 분리하느라 시간을 많이 들였습니다.

## ✅ PR 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?