### PR TITLE
[Outside] FAQ 글자 제한 및 텍스트 리셋

### DIFF
--- a/shared/common/src/components/FAQAnswerItem/index.tsx
+++ b/shared/common/src/components/FAQAnswerItem/index.tsx
@@ -5,6 +5,9 @@ import { useEffect, useState } from 'react'
 import { toast } from 'react-toastify'
 import * as S from './style'
 
+const QUESTIONMXLENGTH: number = 100 as const
+const ANSWERMAXLENGTH: number = 3000 as const
+
 const FAQAnswerItem = ({ refetchFAQs }: { refetchFAQs: () => void }) => {
   const tokenManager = new TokenManager()
   const [answerStatus, setAnswerStatus] = useState<boolean>(false)
@@ -15,6 +18,8 @@ const FAQAnswerItem = ({ refetchFAQs }: { refetchFAQs: () => void }) => {
   const { mutate } = usePostQuestion({
     onSuccess: () => {
       toast.success('작성되었습니다.')
+      setQuestion('')
+      setAnswer('')
       refetchFAQs()
     },
     onError: () => {
@@ -59,6 +64,7 @@ const FAQAnswerItem = ({ refetchFAQs }: { refetchFAQs: () => void }) => {
             placeholder='질문 작성하기'
             value={question}
             onChange={(e) => setQuestion(e.target.value)}
+            maxLength={QUESTIONMXLENGTH}
           />
         </S.InputWrapper>
         <S.InputWrapper>
@@ -67,6 +73,7 @@ const FAQAnswerItem = ({ refetchFAQs }: { refetchFAQs: () => void }) => {
             placeholder='답변 작성하기'
             value={answer}
             onChange={(e) => setAnswer(e.target.value)}
+            maxLength={ANSWERMAXLENGTH}
           />
         </S.InputWrapper>
         <S.ButtonWrapper>


### PR DESCRIPTION
## 💡 배경 및 개요
- faq 작성하고 다른 faq를 작성하려고 하면 전에 작성했던 faq 내용이 남아있습니다.
- faq 서버에서 지정해 둔 길이보다 길게 작성하면 오류가 뜨는데 프론트에서 미리 막는 게 좋아보입니다. 서버에서는 제목은 100자, 내용은 3000자로 설정했습니다.

## 📃 작업내용
- 새내용 작성시 state 초기화
- maxLength 설정

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
