### PR TITLE
[Admin, Type] 관리자 동아리 페이지에서 학교 이름 표시 

### DIFF
--- a/packages/outside/src/PageContainer/Club/ClubPage/index.tsx
+++ b/packages/outside/src/PageContainer/Club/ClubPage/index.tsx
@@ -23,7 +23,7 @@ const ClubPage = () => {
           {isLoading && <WaitingAnimation title={'취업 동아리 목록을'} />}
           {data?.schools.map((school) => (
             <MainStyle.MainContainer key={school.id}>
-              <S.ClubSchoolTitle>{school.schoolName}</S.ClubSchoolTitle>
+              <S.ClubSchoolTitle>{school.name}</S.ClubSchoolTitle>
               <S.ClubListWrapper>
                 {school?.clubs && school.clubs.length <= 0 ? (
                   <S.NoneClubMessage>

--- a/shared/types/src/api/client/SchoolClubListResponseTypes.ts
+++ b/shared/types/src/api/client/SchoolClubListResponseTypes.ts
@@ -3,9 +3,7 @@ export interface ClubType {
   name: string
 }
 
-interface SchoolClubListType {
-  id: string
-  schoolName: string
+interface SchoolClubListType extends ClubType{
   clubs: ClubType[]
 }
 


### PR DESCRIPTION
## 💡 배경 및 개요
학교 목록을 가져오는 API에서 학교의 이름은 name인데 코드에서는
schoolName이란 이름을 사용하고 있었습니다.

Resolves: #345 

## 📃 작업내용
- schoolName -> name으로 변경

## ✅ PR 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?