### PR TITLE
[Admin] 관리자 페이지의 직업 행 수정

### DIFF
--- a/packages/outside/src/PageContainer/Admin/UserListPage/index.tsx
+++ b/packages/outside/src/PageContainer/Admin/UserListPage/index.tsx
@@ -9,15 +9,13 @@ import {
   NoneResult,
   WaitingAnimation,
   insertHyphen,
+  roleToKor,
   useFilterSelect,
-  useModal
+  useModal,
 } from '@bitgouel/common'
-import {CompoundListItemComponent} from '@bitgouel/common'
+import { CompoundListItemComponent } from '@bitgouel/common'
 import { RoleEnumTypes } from '@bitgouel/types'
-import {
-  ListManagementContent,
-  UserDisplayInfo,
-} from '@outside/components'
+import { ListManagementContent, UserDisplayInfo } from '@outside/components'
 import { AdminItemListContainer } from '@outside/components/AdminListComponent/style'
 import { ScrollListModal } from '@outside/modals'
 import { FormEvent, useEffect, useState } from 'react'
@@ -95,7 +93,7 @@ const UserListPage = () => {
             refetch={refetch}
             filterProps={{ title: '권한', filterList, onSelected }}
           />
-          <UserDisplayInfo />
+          {data?.users.length > 0 && <UserDisplayInfo />}
           <AdminItemListContainer>
             {isLoading && <WaitingAnimation title={'사용자 목록을'} />}
             {data?.users.length <= 0 ? (
@@ -103,7 +101,7 @@ const UserListPage = () => {
             ) : (
               data?.users.map((user) => {
                 const otherItemList: { width: string; text: string }[] = [
-                  { width: '8rem', text: user.authority },
+                  { width: '8rem', text: roleToKor[user.authority] },
                   { width: '9rem', text: insertHyphen(user.phoneNumber) },
                   {
                     width: '9rem',

--- a/packages/outside/src/PageContainer/Admin/UserListPage/index.tsx
+++ b/packages/outside/src/PageContainer/Admin/UserListPage/index.tsx
@@ -101,7 +101,7 @@ const UserListPage = () => {
             ) : (
               data?.users.map((user) => {
                 const otherItemList: { width: string; text: string }[] = [
-                  { width: '8rem', text: roleToKor[user.authority] },
+                  { width: '8.25rem', text: roleToKor[user.authority] },
                   { width: '9rem', text: insertHyphen(user.phoneNumber) },
                   {
                     width: '9rem',

--- a/packages/outside/src/components/AdminDisplayInfo/NewDisplayInfo/index.tsx
+++ b/packages/outside/src/components/AdminDisplayInfo/NewDisplayInfo/index.tsx
@@ -16,7 +16,7 @@ const NewDisplayInfo = ({ onAll, handleOpenModal }: Props) => {
           <DisplayBarSpan width="1.75rem">선택</DisplayBarSpan>
           <DisplayBarSpan width="6rem">이름</DisplayBarSpan>
         </div>
-        <DisplayBarSpan width="8rem">직업</DisplayBarSpan>
+        <DisplayBarSpan width="8.25rem">직업</DisplayBarSpan>
         <DisplayBarSpan width="9rem">전화번호</DisplayBarSpan>
         <DisplayBarSpan width="auto">이메일</DisplayBarSpan>
       </RequestDisplayBar>

--- a/packages/outside/src/components/AdminDisplayInfo/UserDisplayInfo/index.tsx
+++ b/packages/outside/src/components/AdminDisplayInfo/UserDisplayInfo/index.tsx
@@ -4,7 +4,7 @@ const UserDisplayInfo = () => {
   return (
     <DisplayBar>
       <DisplayBarSpan width='6rem'>이름</DisplayBarSpan>
-      <DisplayBarSpan width='8rem'>직업</DisplayBarSpan>
+      <DisplayBarSpan width='8.25rem'>직업</DisplayBarSpan>
       <DisplayBarSpan width='9rem'>전화번호</DisplayBarSpan>
       <DisplayBarSpan width='9rem'>가입년도 (가입 당시 학년)</DisplayBarSpan>
       <DisplayBarSpan width='auto'>이메일</DisplayBarSpan>

--- a/packages/outside/src/components/AdminDisplayInfo/WithdrawDisplayInfo/index.tsx
+++ b/packages/outside/src/components/AdminDisplayInfo/WithdrawDisplayInfo/index.tsx
@@ -34,7 +34,7 @@ const WithdrawDisplayInfo = ({
           <DisplayBarSpan width='1.75rem'>선택</DisplayBarSpan>
           <DisplayBarSpan width='6rem'>이름</DisplayBarSpan>
         </div>
-        <DisplayBarSpan width='8rem'>직업</DisplayBarSpan>
+        <DisplayBarSpan width='8.25rem'>직업</DisplayBarSpan>
         <DisplayBarSpan width='9rem'>전화번호</DisplayBarSpan>
         <DisplayBarSpan width='auto'>이메일</DisplayBarSpan>
       </RequestDisplayBar>

--- a/packages/outside/src/components/AdminListComponent/NewUserList/index.tsx
+++ b/packages/outside/src/components/AdminListComponent/NewUserList/index.tsx
@@ -10,6 +10,7 @@ import {
   WaitingAnimation,
   handleSelect,
   insertHyphen,
+  roleToKor,
   useModal,
 } from '@bitgouel/common'
 import { AppropriationModalProps } from '@bitgouel/types'
@@ -88,7 +89,7 @@ const NewUserList = () => {
         ) : (
           data?.users.map((user) => {
             const otherItemList: { width: string; text: string }[] = [
-              { width: '8rem', text: user.authority },
+              { width: '8.25rem', text: roleToKor[user.authority] },
               { width: '9rem', text: insertHyphen(user.phoneNumber) },
               { width: 'auto', text: user.email },
             ]

--- a/packages/outside/src/components/AdminListComponent/WithdrawUserList/index.tsx
+++ b/packages/outside/src/components/AdminListComponent/WithdrawUserList/index.tsx
@@ -6,6 +6,7 @@ import {
   WaitingAnimation,
   handleSelect,
   insertHyphen,
+  roleToKor,
   useFilterSelect,
   useModal,
 } from '@bitgouel/common'
@@ -80,7 +81,7 @@ const WithdrawUserList = () => {
         ) : (
           data?.students.map((user) => {
             const userItemList: { width: string; text: string }[] = [
-              { width: '8rem', text: user.authority },
+              { width: '8.25rem', text: roleToKor[user.authority] },
               { width: '9rem', text: insertHyphen(user.phoneNumber) },
               { width: 'auto', text: user.email },
             ]


### PR DESCRIPTION
## 💡 배경 및 개요
직업이 서버에서 받아오는 ENUM 그대로 보여주고 있었고
한글로 변환했을 때는 width가 맞지 않아 한 줄 내려가는 문제가 있었습니다.
Resolves: #349 

## 📃 작업내용
- user.authority를 roleToKor로 변환
- 직업 행의 width 변경 ( 사용자 명단, 신규 가입자 명단, 탈퇴 예정자 명단 )

## ✅ PR 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?