### PR TITLE
[Api, Common] 엑셀 다운로드 비동기 처리

### DIFF
--- a/shared/api/admin/src/hooks/lecture/useGetLectureExcel.ts
+++ b/shared/api/admin/src/hooks/lecture/useGetLectureExcel.ts
@@ -2,7 +2,9 @@ import { get, lectureQueryKeys, lectureUrl } from '@bitgouel/api'
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
 
-export const useGetLectureExcel = (options?: UseQueryOptions<ArrayBuffer>) =>
+export const useGetLectureExcel = (
+  options?: UseQueryOptions<ArrayBuffer, AxiosError>
+) =>
   useQuery<ArrayBuffer, AxiosError>(
     lectureQueryKeys.getExcel(),
     () =>

--- a/shared/common/src/pages/lecture/page/index.tsx
+++ b/shared/common/src/pages/lecture/page/index.tsx
@@ -66,19 +66,25 @@ const LecturePage = ({ isAdmin }: { isAdmin: boolean }) => {
   const {
     data: applyExcel,
     refetch,
-    isError,
+    error,
   } = useGetLectureExcel({
     enabled: false,
   })
 
-  const onDownload = () => {
-    refetch()
-    if (isError) return toast.error('취업 동아리 선생님이 배정되지 않았습니다')
-    excelDownload({
-      data: applyExcel,
-      fileName: '강의 신청 명단',
-      fileExtension: 'xlsx',
-    })
+  const onDownload = async () => {
+    try {
+      const response = await refetch()
+      if (response.error) throw response.error
+
+      excelDownload({
+        data: response.data,
+        fileName: '강의 신청 명단',
+        fileExtension: 'xlsx',
+      })
+    } catch (e) {
+      if (e.response.status === 404)
+        toast.error('취업 동아리 선생님이 배정되지 않았습니다')
+    }
   }
 
   return (

--- a/shared/common/src/utils/excelDownload.ts
+++ b/shared/common/src/utils/excelDownload.ts
@@ -12,8 +12,6 @@ const fileTypes = {
 }
 
 const excelDownload = ({ data, fileName, fileExtension }: Parameter) => {
-  if (!data) return toast.error('다운로드 버튼을 다시 눌러주세요.')
-
   if (data instanceof Blob) {
     const fileBlob: Blob = new Blob([data], {
       type: fileTypes[fileExtension],


### PR DESCRIPTION
## 💡 배경 및 개요
Resolves: #392 

## 📃 작업내용
- useGetLectureExcel의 options 타입에 AxiosError 타입 추가
- onDownload 함수를 비동기 함수로 변경해 에러 처리에 유연하도록 변경
- excelDownload에서 하던 에러 검사 코드 제거

## ✅ PR 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?