### PR TITLE
[Common] 학생 정보 일괄 삽입의 onError에서 구조 분해 할당하는 요소 수정

### DIFF
--- a/shared/common/src/pages/my/index.tsx
+++ b/shared/common/src/pages/my/index.tsx
@@ -43,20 +43,23 @@ const MyPage = ({ isAdmin }: { isAdmin: boolean }) => {
 
   const { mutate: upload } = usePostExcelUpload({
     onSuccess: () => toast.success('엑셀이 업로드 되었습니다'),
-    onError: ({ status }) => handleErrorStatus(status as number)
+    onError: ({ response }) => response && handleErrorStatus(response.status),
   })
 
-  const onFileUpload = useCallback((e: ChangeEvent<HTMLInputElement>) => {
-    const excelFile: File | null = e.currentTarget.files
-      ? e.currentTarget.files[0]
-      : null
+  const onFileUpload = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const excelFile: File | null = e.currentTarget.files
+        ? e.currentTarget.files[0]
+        : null
 
-    const formData = new FormData()
-    formData.append('file', excelFile ?? '')
-    upload(formData)
-    
-    e.currentTarget.value = ''
-  }, [upload])
+      const formData = new FormData()
+      formData.append('file', excelFile ?? '')
+      upload(formData)
+
+      e.currentTarget.value = ''
+    },
+    [upload]
+  )
 
   const onWithdraw = () =>
     openModal(


### PR DESCRIPTION
## 💡 배경 및 개요
Resolves: #403 

## 📃 작업내용
- ({ status })에서 ({ response })로 구조분해하여 handleErrorStatus에 response.status로 에러 코드를 넘겨줌

## ✅ PR 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?