### PR TITLE
[Admin] 동아리 리스트, 나의 정보 불러오기 API 오류 해결

### DIFF
--- a/shared/api/client/src/hooks/club/useGetClubDetail.ts
+++ b/shared/api/client/src/hooks/club/useGetClubDetail.ts
@@ -7,7 +7,6 @@ export const useGetClubDetail = (
   clubId: string,
   options?: UseQueryOptions<ClubDetailResponseTypes>
 ) => {
-  console.log(clubId)
   return useQuery<ClubDetailResponseTypes, AxiosError>(
     clubQueryKeys.getClubDetail(clubId),
     () => get(clubUrl.clubDetail(clubId)),

--- a/shared/api/client/src/hooks/club/useGetClubDetail.ts
+++ b/shared/api/client/src/hooks/club/useGetClubDetail.ts
@@ -4,11 +4,13 @@ import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { AxiosError, AxiosResponse } from 'axios'
 
 export const useGetClubDetail = (
-  club_id: string,
+  clubId: string,
   options?: UseQueryOptions<ClubDetailResponseTypes>
-) =>
-  useQuery<ClubDetailResponseTypes, AxiosError>(
-    clubQueryKeys.getClubDetail(),
-    () => get(clubUrl.clubDetail(club_id)),
+) => {
+  console.log(clubId)
+  return useQuery<ClubDetailResponseTypes, AxiosError>(
+    clubQueryKeys.getClubDetail(clubId),
+    () => get(clubUrl.clubDetail(clubId)),
     options
   )
+}

--- a/shared/api/common/src/libs/queryKeys.ts
+++ b/shared/api/common/src/libs/queryKeys.ts
@@ -89,7 +89,7 @@ export const certificateQueryKeys = {
 export const clubQueryKeys = {
   getSchoolClub: () => ['club', 'schoolClub'],
   getClub: () => ['club', 'clubList'],
-  getClubDetail: () => ['club', 'detail'],
+  getClubDetail: (id: string) => ['club', 'detail', id],
   getMyClub: () => ['club', 'myClub'],
   getStudentDetail: (id: string, studentId: string) => [
     'club',

--- a/shared/common/src/pages/club/detail/index.tsx
+++ b/shared/common/src/pages/club/detail/index.tsx
@@ -20,7 +20,7 @@ const ClubDetailPage = ({ clubId }: { clubId?: string }) => {
 
   const { data: clubDetail, isLoading } = useGetClubDetail(clubId || '', {
     enabled: !!clubId,
-  }) //관지자
+  }) //관리자
   const { data: myClub } = useGetMyClub({ enabled: !clubId }) //학생
   const { data: myData } = useGetMy()
 

--- a/shared/common/src/pages/club/detail/index.tsx
+++ b/shared/common/src/pages/club/detail/index.tsx
@@ -16,7 +16,6 @@ import * as S from './style'
 const ClubDetailPage = ({ clubId }: { clubId?: string }) => {
   const { push } = useRouter()
   const authority = useContext(AuthorityContext)
-  console.log(authority)
 
   const { data: clubDetail, isLoading } = useGetClubDetail(clubId || '', {
     enabled: !!clubId,

--- a/shared/common/src/pages/club/detail/index.tsx
+++ b/shared/common/src/pages/club/detail/index.tsx
@@ -16,11 +16,12 @@ import * as S from './style'
 const ClubDetailPage = ({ clubId }: { clubId?: string }) => {
   const { push } = useRouter()
   const authority = useContext(AuthorityContext)
+  console.log(authority)
 
   const { data: clubDetail, isLoading } = useGetClubDetail(clubId || '', {
-    enabled: authority === 'ROLE_ADMIN',
-  })
-  const { data: myClub } = useGetMyClub({ enabled: authority !== 'ROLE_ADMIN' })
+    enabled: !!clubId,
+  }) //관지자
+  const { data: myClub } = useGetMyClub({ enabled: !clubId }) //학생
   const { data: myData } = useGetMy()
 
   const [userId, setUserId] = useState<string>('')
@@ -69,7 +70,7 @@ const ClubDetailPage = ({ clubId }: { clubId?: string }) => {
             <S.ClubInfoBox>
               <div>소속 학교</div>
               <span>
-                {clubId ? clubDetail?.highSchoolName : myClub?.highSchoolName}
+                {clubId ? clubDetail?.schoolName : myClub?.schoolName}
               </span>
             </S.ClubInfoBox>
             <S.ClubInfoBox>

--- a/shared/types/src/api/client/ClubDetailResponseTypes.ts
+++ b/shared/types/src/api/client/ClubDetailResponseTypes.ts
@@ -7,7 +7,7 @@ interface StudentType {
 export interface ClubDetailResponseTypes {
   clubId: number
   clubName: string
-  highSchoolName: string
+  schoolName: string
   headCount: number
   students: StudentType[]
   teacher: { id: string; name: string }


### PR DESCRIPTION
## 💡 배경 및 개요

> 기존에 어드민에서 동아리 리스트와 정보 불러오기에 대한 400대 코드 발생

Resolves: #407

## 📃 작업내용

> 1. clubDetail에 있는 queryKey에 clubId 값 추가하였습니다.
> 2. 기존에 authority를 통해서 관리하던 API를 clubId로 판별하여 enabled하였습니다.
> 3. highSchoolName의 네이밍을 schoolName으로 변경하였습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
