### PR TITLE
[Admin, Common] handleErrorStatus util 함수 생성 및 적용

### DIFF
--- a/packages/outside/src/components/ClubBanner/index.tsx
+++ b/packages/outside/src/components/ClubBanner/index.tsx
@@ -4,6 +4,7 @@ import { useGetClubExcel, usePostClubExcelUpload } from '@bitgouel/api'
 import {
   Bg2,
   excelDownload,
+  handleErrorStatus,
   ListDocumentIcon,
   MainStyle,
   PrintIcon,
@@ -14,6 +15,12 @@ import {
 import { ScrollListModal } from '@outside/modals'
 import { toast } from 'react-toastify'
 import SchoolContent from '../SchoolContent'
+
+const errorStatusMap: { [key: number]: () => void } = {
+  400: () => toast.error('유효하지 않은 동아리 분야입니다.'),
+  404: () => toast.error('셀에 존재하지 않는 학교가 기재되어 있습니다.'),
+  409: () => toast.error('이미 등록된 동아리가 셀에 기재되어 있습니다.'),
+}
 
 const ClubBanner = () => {
   const { openModal } = useModal()
@@ -37,22 +44,10 @@ const ClubBanner = () => {
     }
   }
 
-  const handleErrorStatus = (status: number) => {
-    const statusMap = {
-      400: () => toast.error('유효하지 않은 동아리 분야입니다.'),
-      404: () => toast.error('셀에 존재하지 않는 학교가 기재되어 있습니다.'),
-      409: () => toast.error('이미 등록된 동아리가 셀에 기재되어 있습니다.'),
-    }
-
-    if (status >= 500) return toast.error('서버 오류가 발생했습니다')
-
-    const inputStatus = statusMap[status]
-    if (inputStatus) inputStatus()
-  }
-
   const { mutate: upload } = usePostClubExcelUpload({
     onSuccess: () => toast.success('동아리 정보 일괄 삽입을 성공했습니다.'),
-    onError: ({ response }) => response && handleErrorStatus(response.status),
+    onError: ({ response }) =>
+      response && handleErrorStatus(response.status, errorStatusMap),
   })
 
   const { onFileUpload } = useFileUpload(upload)

--- a/packages/outside/src/components/ClubBanner/index.tsx
+++ b/packages/outside/src/components/ClubBanner/index.tsx
@@ -41,7 +41,7 @@ const ClubBanner = () => {
     } catch (e) {
       e &&
         handleErrorStatus(e.response.status, {
-          404: () => toast.error('취업 동아리 선생님이 배정되지 않았습니다.'),
+          400: () => toast.error('유효하지 않은 동아리 분야입니다.'),
         })
     }
   }

--- a/packages/outside/src/components/ClubBanner/index.tsx
+++ b/packages/outside/src/components/ClubBanner/index.tsx
@@ -39,8 +39,10 @@ const ClubBanner = () => {
         fileExtension: 'xlsx',
       })
     } catch (e) {
-      if (e.response.status === 404)
-        toast.error('취업 동아리 선생님이 배정되지 않았습니다')
+      e &&
+        handleErrorStatus(e.response.status, {
+          404: () => toast.error('취업 동아리 선생님이 배정되지 않았습니다.'),
+        })
     }
   }
 

--- a/shared/common/src/pages/lecture/page/index.tsx
+++ b/shared/common/src/pages/lecture/page/index.tsx
@@ -10,6 +10,7 @@ import {
   Plus,
   PrintIcon,
   excelDownload,
+  handleErrorStatus,
   useFileUpload,
   useFilterSelect,
   useModal,
@@ -48,6 +49,11 @@ const defaultFilterList = [
   },
 ]
 
+const errorStatusMap: { [key: number]: () => void } = {
+  400: () => toast.error('셀 서식을 텍스트로 변경해주세요.'),
+  404: () => toast.error('셀에 존재하지 않는 강사가 기재되어 있습니다.'),
+}
+
 const filterTitle: string = '강의 유형'
 
 const LectureList = dynamic(
@@ -84,21 +90,10 @@ const LecturePage = ({ isAdmin }: { isAdmin: boolean }) => {
     }
   }
 
-  const handleErrorStatus = (status: number) => {
-    const statusMap = {
-      400: () => toast.error('셀 서식을 텍스트로 변경해주세요.'),
-      404: () => toast.error('셀에 존재하지 않는 강사가 기재되어 있습니다.'),
-    }
-
-    if (status >= 500) return toast.error('서버 오류가 발생했습니다')
-
-    const inputStatus = statusMap[status]
-    if (inputStatus) inputStatus()
-  }
-
   const { mutate: upload } = usePostLectureExcelUpload({
     onSuccess: () => toast.success('강의 일괄 삽입을 성공했습니다.'),
-    onError: ({ response }) => response && handleErrorStatus(response.status),
+    onError: ({ response }) =>
+      response && handleErrorStatus(response.status, errorStatusMap),
   })
 
   const { onFileUpload } = useFileUpload(upload)

--- a/shared/common/src/pages/lecture/page/index.tsx
+++ b/shared/common/src/pages/lecture/page/index.tsx
@@ -85,8 +85,10 @@ const LecturePage = ({ isAdmin }: { isAdmin: boolean }) => {
         fileExtension: 'xlsx',
       })
     } catch (e) {
-      if (e.response.status === 404)
-        toast.error('취업 동아리 선생님이 배정되지 않았습니다')
+      e &&
+        handleErrorStatus(e.response.status, {
+          404: () => toast.error('취업 동아리 선생님이 배정되지 않았습니다.'),
+        })
     }
   }
 

--- a/shared/common/src/pages/my/index.tsx
+++ b/shared/common/src/pages/my/index.tsx
@@ -10,12 +10,18 @@ import {
   AppropriationModal,
   Bg4,
   ChangePwModal,
+  handleErrorStatus,
   roleToKor,
   useFileUpload,
   useModal,
 } from '@bitgouel/common'
 import { toast } from 'react-toastify'
 import * as S from './style'
+
+const errorStatusMap: { [key: number]: () => void } = {
+  400: () => toast.error('전화번호 셀 서식을 텍스트로 바꿔주세요.'),
+  409: () => toast.error('이미 가입된 학생과 일치하는 정보가 있습니다.'),
+}
 
 const MyPage = ({ isAdmin }: { isAdmin: boolean }) => {
   const { openModal } = useModal()
@@ -29,21 +35,10 @@ const MyPage = ({ isAdmin }: { isAdmin: boolean }) => {
     },
   })
 
-  const handleErrorStatus = (status: number) => {
-    const statusMap = {
-      400: () => toast.error('전화번호 셀 서식을 텍스트로 바꿔주세요.'),
-      409: () => toast.error('이미 가입된 학생과 일치하는 정보가 있습니다.'),
-    }
-
-    if (status >= 500) return toast.error('서버 오류가 발생했습니다')
-
-    const inputStatus = statusMap[status]
-    if (inputStatus) inputStatus()
-  }
-
   const { mutate: upload } = usePostStudentExcelUpload({
     onSuccess: () => toast.success('엑셀이 업로드 되었습니다'),
-    onError: ({ response }) => response && handleErrorStatus(response.status),
+    onError: ({ response }) =>
+      response && handleErrorStatus(response.status, errorStatusMap),
   })
 
   const { onFileUpload } = useFileUpload(upload)

--- a/shared/common/src/utils/handleErrorStatus.ts
+++ b/shared/common/src/utils/handleErrorStatus.ts
@@ -1,0 +1,14 @@
+import { toast } from 'react-toastify'
+
+interface ErrorStatusMap {
+  [key: number]: () => void
+}
+
+const handleErrorStatus = (status: number, errorStatusMap: ErrorStatusMap) => {
+  if (status >= 500) return toast.error('서버 오류가 발생했습니다.')
+
+  const statusFn = errorStatusMap[status]
+  if (statusFn) statusFn()
+}
+
+export default handleErrorStatus

--- a/shared/common/src/utils/index.ts
+++ b/shared/common/src/utils/index.ts
@@ -1,3 +1,4 @@
-export { default as handleSelect } from './handleSelect'
 export { default as excelDownload } from './excelDownload'
+export { default as handleErrorStatus } from './handleErrorStatus'
+export { default as handleSelect } from './handleSelect'
 export { default as insertHyphen } from './insertHyphen'


### PR DESCRIPTION
## 💡 배경 및 개요
에러 상태 코드에 따라 toast 알림을 띄우는 util을 엑셀 관련 API 요청에 적용합니다.
Resolves: #413 

## 📃 작업내용
- handleErrorStatus utils 추가
- 동아리 엑셀 업로드 오류 핸들링 수정
- 강의 엑셀 업로드 오류 핸들링 수정
- 학생 엑셀 업로드 오류 핸들링 수정
- 동아리 엑셀 다운로드 오류 핸들링 수정
- 강의 신청 명단 엑셀 다운로드 오류 핸들링 수정

## ✅ PR 체크리스트
- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?